### PR TITLE
Fix broken markdown link

### DIFF
--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -1392,7 +1392,7 @@ components:
         \ The authorization code flow allows your users to **login with lichess**.\n\
         \ - [NodeJS example](https://github.com/lichess-org/api/tree/master/example/oauth-authorization-code)\n\
         \ - [Create a Lichess OAuth app](https://lichess.org/account/oauth/app)\n\
-        \ - [About authorization code flow]( [More info](https://www.digitalocean.com/community/tutorials/an-introduction-to-oauth-2)\n\
+        \ - [About authorization code flow](https://www.digitalocean.com/community/tutorials/an-introduction-to-oauth-2#grant-type-authorization-code)\n\
         \n### Personal API Token\n\
         \ Personal API tokens allow you to quickly interact with Lichess OAuth API.\n\
         \ - `curl https://lichess.org/account/me -H \"Authorization: Bearer <token>\"`\n\


### PR DESCRIPTION
Fixes the broken markdown and also updates the link to go directly to the "authorization code flow" paragraph.