### PR TITLE
update api url for doc page

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -8,7 +8,7 @@
     <style>body { margin: 0; padding: 0; }</style>
   </head>
   <body>
-    <redoc spec-url="https://raw.githubusercontent.com/lichess-org/api/master/doc/lichess-api.yaml"></redoc>
+    <redoc spec-url="https://raw.githubusercontent.com/lichess-org/api/master/doc/specs/lichess-api.yaml"></redoc>
     <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
   </body>
 </html>


### PR DESCRIPTION
Currently the api url is incorrect as the file was moved into the specs folder. i've just updated that so that docs can be run locally.