### PR TITLE
Add golang lichess bot

### DIFF
--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -50,6 +50,7 @@ tags:
   \n## Integrations\n\
   \ - [Python3 lichess-bot](https://github.com/careless25/lichess-bot) (official)\n\
   \ - [JavaScript bot-o-tron](https://github.com/tailuge/bot-o-tron)\n\
+  \ - [Golang lichess-bot](https://github.com/dolegi/lichess-bot)\n\
   \ - Yours? Please make [an issue or pull request](https://github.com/lichess-org/api).\n\
   \n## Links\n\
   \ - Join the [Lichess Bots team](https://lichess.org/team/lichess-bots) with your bot account\n\


### PR DESCRIPTION
Hello :wave:

I've created a chess bot interface for uci engines in golang. More details about it are available [here](https://github.com/dolegi/lichess-bot). The docs said add a PR.

Let me know what you think :)