### PR TITLE
Additional offeringDraw query param description

### DIFF
--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -2813,7 +2813,7 @@ paths:
             example: "e2e4"
         - in: query
           name: offeringDraw
-          description: Whether to accept (or agree to) a draw
+          description: Whether to offer (or agree to) a draw
           schema:
             type: boolean
       responses:


### PR DESCRIPTION
offeringDraw query param exists both in bot section and board section
Previous Pull Request, #45, updated only one (board) section.

This commit makes sure both sections use the updated description,
"Whether to offer (or agree to) a draw"

https://lichess.org/api#operation/botGameMove
https://lichess.org/api#operation/boardGameMove
