### PR TITLE
fixed user profile field ecfRating being documented as ecf

### DIFF
--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -3722,7 +3722,7 @@ components:
         uscfRating:
           type: integer
           example: 1500
-        ecf:
+        ecfRating:
           type: integer
           example: 1500
         links:


### PR DESCRIPTION
Based on [Profile module](https://github.com/ornicar/lila/blob/master/modules/user/src/main/Profile.scala#L11) and [example response](https://lichess.org/api/user/rowrulz)