### PR TITLE
Add optional challenge decline reason

### DIFF
--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -3215,6 +3215,17 @@ paths:
             type: string
             example: "5IrD6Gzz"
           required: true
+      requestBody:
+        description: Details related to decline of challenge
+        required: false
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                reason:
+                  type: string
+                  description: Reason challenge was declined
       responses:
         200:
           content:


### PR DESCRIPTION
Adds optional challenge decline reason to `POST /api/challenge/{challengeId}/decline`

Related lila issue [here](https://github.com/ornicar/lila/issues/7487).