### PR TITLE
Correct errors in the API spec

### DIFF
--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -5875,6 +5875,8 @@ components:
         moves:
           type: array
           description: Information about legal moves, best first
+          items:
+            $ref: '#/components/schemas/Move'
       example:
         {
           "wdl": 2,
@@ -5901,6 +5903,37 @@ components:
             }
           ]
         }
+
+    Move:
+      type: object
+      properties:
+        uci:
+          type: string
+          example: "h7h8q"
+        san:
+          type: string
+          example: "h8=Q+"
+        wdl:
+          type: integer
+          description: (2) win, (1) cursed win, (0) draw, (-1) blessed loss, (-2) loss, (null) unknown
+        dtz:
+          type: integer
+          description: Distance to zeroing or null if unknown
+        dtm:
+          type: integer
+          description: Distance to mate (only for positions with not more than 5 pieces)
+        zeroing:
+          type: boolean
+        checkmate:
+          type: boolean
+        stalemate:
+          type: boolean
+        variant_win:
+          type: boolean
+        variant_loss:
+          type: boolean
+        insufficient_material:
+          type: boolean
 
     Team:
       type: object

--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -174,6 +174,7 @@ paths:
           example: aliquantus,chess-network,lovlas
       responses:
         200:
+          description: The list of users and their respective statuses.
           content:
             application/json:
               schema:
@@ -232,6 +233,7 @@ paths:
         - $ref: '#/components/parameters/lichess'
       responses:
         200:
+          description: The list of variants with their respective top players.
           content:
             application/vnd.lichess.v3+json:
               schema:
@@ -284,6 +286,7 @@ paths:
           required: true
       responses:
         200:
+          description: The list of top players for the variant.
           content:
             application/vnd.lichess.v3+json:
               schema:
@@ -307,6 +310,7 @@ paths:
           required: true
       responses:
         200:
+          description: The information of the user.
           content:
             application/json:
               schema:
@@ -333,6 +337,7 @@ paths:
           required: true
       responses:
         200:
+          description: The rating history of the user.
           content:
             application/json:
               schema:
@@ -356,6 +361,7 @@ paths:
           required: true
       responses:
         200:
+          description: The activity feed of the user.
           content:
             application/json:
               example:
@@ -373,6 +379,7 @@ paths:
         - None: []
       responses:
         200:
+          description: The daily puzzle.
           content:
             application/x-ndjson:
               schema:
@@ -403,6 +410,7 @@ paths:
             default: null
       responses:
         200:
+          description: The puzzle activity of the logged in user.
           content:
             application/x-ndjson:
               schema:
@@ -432,6 +440,7 @@ paths:
             minimum: 1
       responses:
         200:
+          description: The puzzle dashboard of the logged in user.
           content:
             application/json:
               schema:
@@ -467,6 +476,7 @@ paths:
             default: 30
       responses:
         200:
+          description: The storm dashboard of a player.
           content:
             application/json:
               schema:
@@ -494,6 +504,7 @@ paths:
             example: "aliquantus,chess-network,lovlas"
       responses:
         200:
+          description: The list of users.
           content:
             application/json:
               schema:
@@ -514,6 +525,7 @@ paths:
         - OAuth2: []
       responses:
         200:
+          description: The public informations about the logged in user.
           content:
             application/json:
               schema:
@@ -532,6 +544,7 @@ paths:
         - OAuth2: ["email:read"]
       responses:
         200:
+          description: The email address of the logged in user.
           content:
             application/json:
               schema:
@@ -557,6 +570,7 @@ paths:
         - OAuth2: ["preference:read"]
       responses:
         200:
+          description: The preferences of the logged in user.
           content:
             application/json:
               schema:
@@ -579,6 +593,7 @@ paths:
         - OAuth2: ["preference:read"]
       responses:
         200:
+          description: The kid mode status of the logged in user.
           content:
             application/json:
               schema:
@@ -609,6 +624,7 @@ paths:
           example: true
       responses:
         200:
+          description: The kid mode status was set successfully for the logged in user.
           content:
             application/json:
               schema:
@@ -696,6 +712,7 @@ paths:
             type: string
       responses:
         200:
+          description: The game representation.
           content:
             application/x-chess-pgn:
               schema:
@@ -785,6 +802,7 @@ paths:
             type: string
       responses:
         200:
+          description: The ongoing (or last) game of a user.
           content:
             application/x-chess-pgn:
               schema:
@@ -955,6 +973,7 @@ paths:
             type: string
       responses:
         200:
+          description: The games of the user.
           content:
             application/x-chess-pgn:
               schema:
@@ -1044,6 +1063,7 @@ paths:
             type: string
       responses:
         200:
+          description: The representation of the games.
           content:
             application/x-chess-pgn:
               schema:
@@ -1079,6 +1099,7 @@ paths:
             example: aliquantus,chess-network,lovlas
       responses:
         200:
+          description: The stream of the games played between the users.
           content:
             application/x-ndjson:
               schema:
@@ -1108,6 +1129,7 @@ paths:
             maximum: 50
       responses:
         200:
+          description: The ongoing games of the logged in user.
           content:
             application/json:
               schema:
@@ -1128,6 +1150,7 @@ paths:
         - None: []
       responses:
         200:
+          description: The list of games being played for each speed and variant.
           content:
             application/json:
               schema:
@@ -1148,6 +1171,7 @@ paths:
         - SameOrigin: []
       responses:
         200:
+          description: The stream of the current TV game.
           content:
             application/x-ndjson:
               schema:
@@ -1183,6 +1207,7 @@ paths:
                   description: The PGN. It can contain only one game. Most standard tags are supported.
       responses:
         200:
+          description: The game was successfully imported.
           content:
             application/json:
               schema:
@@ -1202,6 +1227,7 @@ paths:
         - None: []
       responses:
         200:
+          description: The list of current tournaments.
           content:
             application/json:
               schema:
@@ -1353,11 +1379,13 @@ paths:
                 - minutes
       responses:
         200:
+          description: The Arena tournament has been successfully created.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ArenaTournament'
         400:
+          description: The creation of the Arena tournament failed.
           content:
             application/json:
               schema:
@@ -1391,6 +1419,7 @@ paths:
             maximum: 200
       responses:
         200:
+          description: The information of the Arena tournament.
           content:
             application/json:
               schema:
@@ -1525,11 +1554,13 @@ paths:
                 - minutes
       responses:
         200:
+          description: The Arena tournament was successfully updated.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ArenaTournament'
         400:
+          description: The update of the Arena tournament failed.
           content:
             application/json:
               schema:
@@ -1577,11 +1608,13 @@ paths:
                   - nbLeaders
         responses:
           200:
+            description: The team battle tournament was successfully updated.
             content:
               application/json:
                 schema:
                   $ref: '#/components/schemas/ArenaTournament'
           400:
+            description: The update of the team battle tournament failed.
             content:
               application/json:
                 schema:
@@ -1653,6 +1686,7 @@ paths:
             default: false
       responses:
         200:
+          description: The list of games of an Arena tournament.
           content:
             application/x-chess-pgn:
               schema:
@@ -1692,6 +1726,7 @@ paths:
             minimum: 1
       responses:
         200:
+          description: The results of the Arena tournament.
           content:
             application/x-ndjson:
               schema:
@@ -1716,6 +1751,7 @@ paths:
           required: true
       responses:
         200:
+          description: The list of teams of a team battle tournament, with their respective top players.
           content:
             application/json:
               schema:
@@ -1744,6 +1780,7 @@ paths:
             minimum: 1
       responses:
         200:
+          description: The list of tournaments created by the user.
           content:
             application/x-ndjson:
               schema:
@@ -1846,11 +1883,13 @@ paths:
                 - nbRounds
       responses:
         200:
+          description: The Swiss tournament was successfully created.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/SwissTournament'
         400:
+          description: The creation of the Swiss tournament failed.
           content:
             application/json:
               schema:
@@ -1879,6 +1918,7 @@ paths:
           required: true
       responses:
         200:
+          description: The TRF representation of a Swiss tournament.
           content:
             text/plain:
               example:
@@ -1949,6 +1989,7 @@ paths:
             default: false
       responses:
         200:
+          description: The list of games of a Swiss tournament.
           content:
             application/x-chess-pgn:
               schema:
@@ -1988,6 +2029,7 @@ paths:
             minimum: 1
       responses:
         200:
+          description: The results of a Swiss tournament.
           content:
             application/x-ndjson:
               schema:
@@ -2024,6 +2066,7 @@ paths:
             default: 100
       responses:
         200:
+          description: The list of Swiss tournaments of a team.
           content:
             application/json:
               schema:
@@ -2083,6 +2126,7 @@ paths:
             default: true
       responses:
         200:
+          description: The chapter of the study.
           content:
             application/x-chess-pgn:
               schema:
@@ -2134,6 +2178,7 @@ paths:
             default: true
       responses:
         200:
+          description: The PGN representation of the study.
           content:
             application/x-chess-pgn:
               schema:
@@ -2191,6 +2236,7 @@ paths:
             default: true
       responses:
         200:
+          description: The studies of the user.
           content:
             application/x-chess-pgn:
               schema:
@@ -2217,6 +2263,7 @@ paths:
             minimum: 1
       responses:
         200:
+          description: The list of official broadcasts.
           content:
             application/json:
               schema:
@@ -2288,11 +2335,13 @@ paths:
                 - description
       responses:
         200:
+          description: The broadcast was successfully created.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Broadcast'
         400:
+          description: The creation of the broadcast failed.
           content:
             application/json:
               schema:
@@ -2327,6 +2376,7 @@ paths:
             type: string
       responses:
         200:
+          description: The information about the broadcast.
           content:
             application/json:
               schema:
@@ -2413,11 +2463,13 @@ paths:
                   - description
         responses:
           200:
+            description: The broadcast was successfully edited.
             content:
               application/json:
                 schema:
                   $ref: '#/components/schemas/Broadcast'
           400:
+            description: The edition of the broadcast failed.
             content:
               application/json:
                 schema:
@@ -2459,6 +2511,7 @@ paths:
               type: string
       responses:
         200:
+          description: The broadcast was successfully updated.
           content:
             application/json:
               schema:
@@ -2478,6 +2531,7 @@ paths:
         - None: []
       responses:
         200:
+          description: The list of simuls.
           content:
             application/json:
               schema:
@@ -2502,6 +2556,7 @@ paths:
           required: true
       responses:
         200:
+          description: The information about the team.
           content:
             application/json:
               schema:
@@ -2526,6 +2581,7 @@ paths:
             default: 1
       responses:
         200:
+          description: A paginated list of the most popular teams.
           content:
             application/json:
               schema:
@@ -2552,6 +2608,7 @@ paths:
           required: true
       responses:
         200:
+          description: The list of teams the user is a member of.
           content:
             application/json:
               schema:
@@ -2583,6 +2640,7 @@ paths:
             default: 1
       responses:
         200:
+          description: The paginated list of teams.
           content:
             application/json:
               schema:
@@ -2612,6 +2670,7 @@ paths:
           required: true
       responses:
         200:
+          description: The list of users in the team.
           content:
             application/x-ndjson:
               schema:
@@ -2648,6 +2707,7 @@ paths:
             default: 100
       responses:
         200:
+          description: The list of Arena tournaments of a team.
           content:
             application/json:
               schema:
@@ -2693,6 +2753,7 @@ paths:
                   description: Optional password, if the team requires one.
       responses:
         200:
+          description: The request to join a team was successfully sent.
           content:
             application/json:
               schema:
@@ -2720,6 +2781,7 @@ paths:
           required: true
       responses:
         200:
+          description: The logged in user has successfully left the team.
           content:
             application/json:
               schema:
@@ -2753,6 +2815,7 @@ paths:
           required: true
       responses:
         200:
+          description: The member has been kicked from the team.
           content:
             application/json:
               schema:
@@ -2789,11 +2852,13 @@ paths:
                   description: The message to send to all your team members.
       responses:
         200:
+          description: The message has successfully been sent to all team members.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Ok'
         400:
+          description: The sending of message to all team members has failed.
           content:
             application/json:
               schema:
@@ -2815,6 +2880,7 @@ paths:
           SameOrigin: []
       responses:
         200:
+          description: The list of live streamers and their respective information.
           content:
             application/json:
               schema:
@@ -2879,6 +2945,7 @@ paths:
             type: boolean
       responses:
         200:
+          description: The crosstable of the two users.
           content:
             application/json:
               schema:
@@ -2903,6 +2970,7 @@ paths:
           required: true
       responses:
         200:
+          description: The list of users followed by a user.
           content:
             application/x-ndjson:
               schema:
@@ -2927,6 +2995,7 @@ paths:
           required: true
       responses:
         200:
+          description: The list of users who follow a user.
           content:
             application/x-ndjson:
               schema:
@@ -2953,6 +3022,7 @@ paths:
         - OAuth2: ["challenge:read", "bot:play", "board:play"]
       responses:
         200:
+          description: The stream of events reaching the logged in user.
           content:
             text/plain:
               example: |
@@ -3032,10 +3102,12 @@ paths:
                 - increment
       responses:
         200:
+          description: The seek was successfully created.
           content:
             text/plain:
               example: ""
         400:
+          description: The creation of the seek failed.
           content:
             application/json:
               schema:
@@ -3066,11 +3138,13 @@ paths:
           required: true
       responses:
         200:
+          description: The stream of the game.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/BotGameState'
         404:
+          description: The game was not found.
           content:
             application/json:
               schema:
@@ -3109,11 +3183,13 @@ paths:
             type: boolean
       responses:
         200:
+          description: The move was successfully made.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Ok'
         400:
+          description: The move failed.
           content:
             application/json:
               schema:
@@ -3156,11 +3232,13 @@ paths:
                 - text
       responses:
         200:
+          description: The message was successfully posted in the chat.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Ok'
         400:
+          description: The posting of the message in the chat failed.
           content:
             application/json:
               schema:
@@ -3185,11 +3263,13 @@ paths:
           required: true
       responses:
         200:
+          description: The game successfully aborted.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Ok'
         400:
+          description: The abortion of the game failed.
           content:
             application/json:
               schema:
@@ -3214,11 +3294,13 @@ paths:
           required: true
       responses:
         200:
+          description: The game was successfully resigned.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Ok'
         400:
+          description: The resigning from the game failed.
           content:
             application/json:
               schema:
@@ -3251,11 +3333,13 @@ paths:
           required: true
       responses:
         200:
+          description: The draw offer was successfully sent.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Ok'
         400:
+          description: The draw offering failed.
           content:
             application/json:
               schema:
@@ -3282,11 +3366,13 @@ paths:
         - OAuth2: ["bot:play"]
       responses:
         200:
+          description: The bot account was successfully upgraded.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Ok'
         400:
+          description: The upgrade of the bot account failed.
           content:
             application/json:
               schema:
@@ -3317,11 +3403,13 @@ paths:
           required: true
       responses:
         200:
+          description: The stream of the bot game.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/BotGameState'
         404:
+          description: The bot game was not found.
           content:
             application/json:
               schema:
@@ -3360,11 +3448,13 @@ paths:
             type: boolean
       responses:
         200:
+          description: The bot move was successfully made.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Ok'
         400:
+          description: The bot move failed.
           content:
             application/json:
               schema:
@@ -3407,11 +3497,13 @@ paths:
                 - text
       responses:
         200:
+          description: The message was successfully posted in chat.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Ok'
         400:
+          description: The posting of the  message in chat failed.
           content:
             application/json:
               schema:
@@ -3436,11 +3528,13 @@ paths:
           required: true
       responses:
         200:
+          description: The game was successfully aborted.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Ok'
         400:
+          description: The abortion of the game failed.
           content:
             application/json:
               schema:
@@ -3465,11 +3559,13 @@ paths:
           required: true
       responses:
         200:
+          description: The game was successfully resigned from.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Ok'
         400:
+          description: Resigning the game failed.
           content:
             application/json:
               schema:
@@ -3575,11 +3671,13 @@ paths:
                   default: "Your game with {opponent} is ready: {game}."
       responses:
         200:
+          description: The challenge was successfully created.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ChallengeJson'
         400:
+          description: The creation of the challenge failed.
           content:
             application/json:
               schema:
@@ -3606,11 +3704,13 @@ paths:
           required: true
       responses:
         200:
+          description: The challenge was successfully accepted.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Ok'
         404:
+          description: The challenge to accept was not found.
           content:
             application/json:
               schema:
@@ -3658,11 +3758,13 @@ paths:
                     - onlyBot
       responses:
         200:
+          description: The challenge was successfully declined.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Ok'
         404:
+          description: The challenge to decline was not found.
           content:
             application/json:
               schema:
@@ -3688,11 +3790,13 @@ paths:
           required: true
       responses:
         200:
+          description: The challenge was successfully cancelled.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Ok'
         404:
+          description: The challenge to cancel was not found.
           content:
             application/json:
               schema:
@@ -3769,11 +3873,13 @@ paths:
                   default: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
       responses:
         200:
+          description: The game with Lichess AI was successfully started.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/GameJson'
         400:
+          description: The creation of a game with Lichess AI failed.
           content:
             application/json:
               schema:
@@ -3846,11 +3952,13 @@ paths:
                   description: Optional name for the challenge, that players will see on the challenge page.
       responses:
         200:
+          description: The challenge was successfully created.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ChallengeOpenJson'
         400:
+          description: The creation of the challenge failed.
           content:
             application/json:
               schema:
@@ -3889,6 +3997,7 @@ paths:
             type: string
       responses:
         200:
+          description: The clock of a game was successfully started.
           content:
             application/json:
               schema:
@@ -3910,6 +4019,7 @@ paths:
         - OAuth2: ["challenge:bulk"]
       responses:
         200:
+          description: The list of upcoming bulk pairing the logged in user created.
           content:
             application/json:
               schema:
@@ -4022,11 +4132,13 @@ paths:
                   default: "Your game with {opponent} is ready: {game}."
       responses:
         200:
+          description: The bulk pairings have been successfully created.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/BulkPairing'
         400:
+          description: The creation of the bulk pairings failed.
           content:
             application/json:
               schema:
@@ -4058,11 +4170,13 @@ paths:
           required: true
       responses:
         200:
+          description: The clocks of the games of a bulk pairing were successfully started.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Ok'
         404:
+          description: The bulk pairing was not found.
           content:
             application/json:
               schema:
@@ -4092,11 +4206,13 @@ paths:
           required: true
       responses:
         200:
+          description: The bulk pairing was successfully deleted.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Ok'
         404:
+          description: The bulk pairing to delete was not found.
           content:
             application/json:
               schema:
@@ -4130,6 +4246,7 @@ paths:
           required: true
       responses:
         200:
+          description: Time was successfully added to the opponent's clock.
           content:
             application/json:
               schema:
@@ -4230,11 +4347,13 @@ paths:
                   default: "Your game with {opponent} is ready: {game}."
       responses:
         200:
+          description: The challenge has been successfully created.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ChallengeJson'
         400:
+          description: The creation of the challenge failed.
           content:
             application/json:
               schema:
@@ -4272,11 +4391,13 @@ paths:
                 - text
       responses:
         200:
+          description: The private message has been successfully sent.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Ok'
         400:
+          description: The sending of the private message has failed.
           content:
             application/json:
               schema:
@@ -4318,6 +4439,7 @@ paths:
             default: standard
       responses:
         200:
+          description: The evaluation of the position.
           content:
             application/json:
               example: {"fen":"rnbqkbnr/ppp1pppp/8/3pP3/8/8/PPPP1PPP/RNBQKBNR b KQkq - 0 2","knodes":13683,"depth":22,"pvs":[{"moves":"c8f5 d2d4 e7e6 g1f3 g8e7 c1e3 c7c5 d4c5 e7c6 b1c3","cp":-13},{"moves":"c7c5 c2c3 d5d4 g1f3 b8c6 c3d4 c6d4 b1c3 c8d7 f1d3","cp":-1},{"moves":"e7e6 d2d4 c7c5 c2c3 b8c6 g1f3 c8d7 b1a3 c5d4 c3d4","cp":24}]}
@@ -4365,6 +4487,7 @@ paths:
             maximum: 4
       responses:
         200:
+          description: The evaluation of the position.
           content:
             application/json:
               schema:
@@ -4453,6 +4576,7 @@ paths:
                 - 2500
       responses:
         200:
+          description: The list of openings.
           content:
             application/json:
               schema:
@@ -4478,6 +4602,7 @@ paths:
           required: true
       responses:
         200:
+          description: The PGN representation of the game.
           content:
             application/x-chess-pgn:
               schema:
@@ -4497,6 +4622,7 @@ paths:
         - None: []
       responses:
         200:
+          description: The statistics of the Opening Explorer.
           content:
             application/json:
               example: {"master":{"games":2299868,"uniquePositions":56683918},"lichess":{"chess960":{"games":2259840,"uniquePositions":190488295},"standard":{"games":272515941,"uniquePositions":7355380242},"antichess":{"games":7818476,"uniquePositions":177073596},"horde":{"games":1027171,"uniquePositions":34843126},"atomic":{"games":3827483,"uniquePositions":70119949},"racingKings":{"games":747878,"uniquePositions":11671677},"kingOfTheHill":{"games":1345370,"uniquePositions":38511395},"crazyhouse":{"games":7540244,"uniquePositions":218945811},"threeCheck":{"games":1362591,"uniquePositions":29181473}}}
@@ -4521,6 +4647,7 @@ paths:
           description: FEN of the position. Underscores allowed. The halfmove clock is taken into account for WDL values.
       responses:
         200:
+          description: The tablebase information for the position in standard chess.
           content:
             application/json:
               schema:

--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -2144,7 +2144,7 @@ paths:
 
   /study/{studyId}.pgn:
     get:
-      operationId: studyChapterPgn
+      operationId: studyAllChaptersPgn
       summary: Export all chapters
       description: |
         Download all chapters of a study in PGN format.

--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -434,6 +434,7 @@ paths:
       parameters:
         - in: path
           name: days
+          required: true
           description: How many days to look back when aggregating puzzle results. 30 is sensible.
           schema:
             type: integer
@@ -466,6 +467,7 @@ paths:
           description: Username of the player
           schema:
             type: string
+          required: true
         - in: query
           name: days
           description: How many days of history to return
@@ -1437,6 +1439,13 @@ paths:
         - "Arena tournaments"
       security:
         - OAuth2: ["tournament:write"]
+      parameters:
+        - in: path
+          name: id
+          description: The tournament ID.
+          schema:
+            type: string
+          required: true
       requestBody:
         description: Parameters of the tournament
         required: true
@@ -1772,12 +1781,12 @@ paths:
       security:
         - None: []
       parameters:
-        - in: query
-          name: nb
-          description: Max number of tournaments to fetch
+        - in: path
+          name: username
+          description: The user whose created tournaments to fetch
           schema:
-            type: integer
-            minimum: 1
+            type: string
+          required: true
       responses:
         200:
           description: The list of tournaments created by the user.
@@ -1801,11 +1810,12 @@ paths:
       security:
         - OAuth2: ["tournament:write"]
       parameters:
-        - in: query
+        - in: path
           name: teamId
           description: ID of the team
           schema:
             type: string
+          required: true
       requestBody:
         description: Parameters of the tournament
         required: true

--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -162,8 +162,7 @@ paths:
         Use it to track players and know when they're connected on lichess and playing games.
       tags:
         - Users
-      security:
-        - None: []
+      security: []
       parameters:
         - in: query
           name: ids
@@ -300,8 +299,7 @@ paths:
         Read public data of a user.
       tags:
         - Users
-      security:
-        - None: []
+      security: []
       parameters:
         - in: path
           name: username
@@ -327,8 +325,7 @@ paths:
         `month` starts at zero (January).
       tags:
         - Users
-      security:
-        - None: []
+      security: []
       parameters:
         - in: path
           name: username
@@ -351,8 +348,7 @@ paths:
         Read data to generate the activity feed of a user.
       tags:
         - Users
-      security:
-        - None: []
+      security: []
       parameters:
         - in: path
           name: username
@@ -375,8 +371,7 @@ paths:
         Get the daily Lichess puzzle in JSON format.
       tags:
         - Puzzles
-      security:
-        - None: []
+      security: []
       responses:
         200:
           description: The daily puzzle.
@@ -459,8 +454,7 @@ paths:
         Use `?days=0` if you only care about the highscores.
       tags:
         - Puzzles
-      security:
-        - None: []
+      security: []
       parameters:
         - in: path
           name: username
@@ -490,8 +484,7 @@ paths:
       summary: Get users by ID
       tags:
         - Users
-      security:
-        - None: []
+      security: []
       description: |
         Get up to 300 users by their IDs. Users are returned in the order same order as the IDs.
 
@@ -642,8 +635,7 @@ paths:
         Ongoing games have their last 3 moves omitted, after move 5.
       tags:
         - Games
-      security:
-        - None: []
+      security: []
       parameters:
         - in: path
           name: gameId
@@ -733,8 +725,7 @@ paths:
         If the game is ongoing, the 3 last moves are omitted.
       tags:
         - Games
-      security:
-        - None: []
+      security: []
       parameters:
         - in: path
           name: username
@@ -833,7 +824,6 @@ paths:
         - Games
         - OAuth
       security:
-        - None: []
         - OAuth2: []
       parameters:
         - in: path
@@ -1089,8 +1079,7 @@ paths:
         The method is `POST` so a longer list of IDs can be sent in the request body.
       tags:
         - Games
-      security:
-        - None: []
+      security: []
       requestBody:
         description: Up to 300 user IDs separated by commas.
         required: true
@@ -1148,8 +1137,7 @@ paths:
         See [lichess.org/tv](https://lichess.org/tv).
       tags:
         - Games
-      security:
-        - None: []
+      security: []
       responses:
         200:
           description: The list of games being played for each speed and variant.
@@ -1194,7 +1182,6 @@ paths:
         - Games
         - OAuth
       security:
-        - None: []
         - OAuth2: []
       requestBody:
         description: A single game to import
@@ -1225,8 +1212,7 @@ paths:
         This API is used to display the [Lichess tournament schedule](https://lichess.org/tournament).
       tags:
         - "Arena tournaments"
-      security:
-        - None: []
+      security: []
       responses:
         200:
           description: The list of current tournaments.
@@ -1401,8 +1387,7 @@ paths:
         Get detailed info about recently finished, current, or upcoming tournament's duels, player standings, and other info.
       tags:
         - "Arena tournaments"
-      security:
-        - None: []
+      security: []
       parameters:
         - in: path
           name: id
@@ -1639,8 +1624,7 @@ paths:
         Games are sorted by reverse chronological order (most recent first)
       tags:
         - "Arena tournaments"
-      security:
-        - None: []
+      security: []
       parameters:
         - in: path
           name: id
@@ -1718,8 +1702,7 @@ paths:
         Use on finished tournaments for guaranteed consistency.
       tags:
         - "Arena tournaments"
-      security:
-        - None: []
+      security: []
       parameters:
         - in: path
           name: id
@@ -1749,8 +1732,7 @@ paths:
         Teams of a team battle tournament, with top players, sorted by rank (best first).
       tags:
         - "Arena tournaments"
-      security:
-        - None: []
+      security: []
       parameters:
         - in: path
           name: id
@@ -1778,8 +1760,7 @@ paths:
         **Tournaments are streamed as [ndjson](http://ndjson.org/)**, i.e. one JSON object per line.
       tags:
         - "Arena tournaments"
-      security:
-        - None: []
+      security: []
       parameters:
         - in: path
           name: username
@@ -1917,8 +1898,7 @@ paths:
         Example: https://lichess.org/swiss/j8rtJ5GL.trf
       tags:
         - "Swiss tournaments"
-      security:
-        - None: []
+      security: []
       parameters:
         - in: path
           name: id
@@ -1943,8 +1923,7 @@ paths:
         Games are sorted by reverse chronological order (last round first)
       tags:
         - "Swiss tournaments"
-      security:
-        - None: []
+      security: []
       parameters:
         - in: path
           name: id
@@ -2022,8 +2001,7 @@ paths:
         Use on finished tournaments for guaranteed consistency.
       tags:
         - "Swiss tournaments"
-      security:
-        - None: []
+      security: []
       parameters:
         - in: path
           name: id
@@ -2058,8 +2036,7 @@ paths:
       tags:
         - Teams
         - "Swiss tournaments"
-      security:
-        - None: []
+      security: []
       parameters:
         - in: path
           name: teamId
@@ -2537,8 +2514,7 @@ paths:
         Get recently finished, ongoing, and upcoming simuls.
       tags:
         - Simuls
-      security:
-        - None: []
+      security: []
       responses:
         200:
           description: The list of simuls.
@@ -2556,8 +2532,7 @@ paths:
       description: Infos about a team
       tags:
         - Teams
-      security:
-        - None: []
+      security: []
       parameters:
         - in: path
           name: teamId
@@ -2580,8 +2555,7 @@ paths:
         Paginator of the most popular teams.
       tags:
         - Teams
-      security:
-        - None: []
+      security: []
       parameters:
         - in: query
           name: page
@@ -2607,8 +2581,7 @@ paths:
         All the teams a player is a member of.
       tags:
         - Teams
-      security:
-        - None: []
+      security: []
       parameters:
         - in: path
           name: username
@@ -2634,8 +2607,7 @@ paths:
         Paginator of team search results for a keyword.
       tags:
         - Teams
-      security:
-        - None: []
+      security: []
       parameters:
         - in: query
           name: text
@@ -2669,8 +2641,7 @@ paths:
       tags:
         - Users
         - Teams
-      security:
-        - None: []
+      security: []
       parameters:
         - in: path
           name: teamId
@@ -2699,8 +2670,7 @@ paths:
       tags:
         - Teams
         - "Arena tournaments"
-      security:
-        - None: []
+      security: []
       parameters:
         - in: path
           name: teamId
@@ -2886,8 +2856,7 @@ paths:
       tags:
         - Users
       security:
-        - None: []
-          SameOrigin: []
+        - SameOrigin: []
       responses:
         200:
           description: The list of live streamers and their respective information.
@@ -2935,8 +2904,7 @@ paths:
         If the `matchup` flag is provided, and the users are currently playing, also gets the current match game number and scores.
       tags:
         - Users
-      security:
-        - None: []
+      security: []
       parameters:
         - in: path
           name: user1
@@ -2969,8 +2937,7 @@ paths:
         **Users are streamed as [ndjson](http://ndjson.org/)**, i.e. one JSON object per line.
       tags:
         - Relations
-      security:
-        - None: []
+      security: []
       parameters:
         - in: path
           name: username
@@ -2994,8 +2961,7 @@ paths:
         **Users are streamed as [ndjson](http://ndjson.org/)**, i.e. one JSON object per line.
       tags:
         - Relations
-      security:
-        - None: []
+      security: []
       parameters:
         - in: path
           name: username
@@ -3914,8 +3880,7 @@ paths:
         with the `acceptByToken` parameter.
       tags:
         - Challenges
-      security:
-        - None: []
+      security: []
       requestBody:
         description: Parameters of the game
         required: true
@@ -4425,8 +4390,7 @@ paths:
         Up to 5 variations may be available. Variants are supported.
       tags:
         - Analysis
-      security:
-        - None: []
+      security: []
       parameters:
         - in: query
           name: fen
@@ -4464,8 +4428,7 @@ paths:
         Example: `curl https://explorer.lichess.ovh/master?fen=rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR%20w%20KQkq%20-%200%201`
       tags:
         - Opening Explorer
-      security:
-        - None: []
+      security: []
       parameters:
         - in: query
           name: fen
@@ -4515,8 +4478,7 @@ paths:
         Example: `curl https://explorer.lichess.ovh/lichess?variant=standard&speeds[]=blitz&speeds[]=rapid&speeds[]=classical&ratings[]=2200&ratings[]=2500&fen=rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR%20w%20KQkq%20-%200%201`
       tags:
         - Opening Explorer
-      security:
-        - None: []
+      security: []
       parameters:
         - in: query
           name: fen
@@ -4602,8 +4564,7 @@ paths:
         Example: `curl https://explorer.lichess.ovh/master/pgn/aAbqI4ey`
       tags:
         - Opening Explorer
-      security:
-        - None: []
+      security: []
       parameters:
         - in: path
           name: gameId
@@ -4628,8 +4589,7 @@ paths:
         Example: `curl https://explorer.lichess.ovh/stats`
       tags:
         - Opening Explorer
-      security:
-        - None: []
+      security: []
       responses:
         200:
           description: The statistics of the Opening Explorer.
@@ -4649,8 +4609,7 @@ paths:
         Example: `curl http://tablebase.lichess.ovh/standard?fen=4k3/6KP/8/8/8/8/7p/8_w_-_-_0_1`
       tags:
         - Tablebase
-      security:
-        - None: []
+      security: []
       parameters:
         - in: query
           name: fen
@@ -6140,8 +6099,4 @@ components:
         \ If you need CORS on one of those, please\n\
         \ [make an issue](https://github.com/ornicar/lila/issues/new)\n\
         \ explaining your use case to request it."
-      type: none
-    None:
-      description: "No authorization required.\n\
-        \ For requests that don't need an authenticated user."
       type: none

--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -2308,9 +2308,7 @@ paths:
                     Timestamp in milliseconds of broadcast start. Leave empty to manually start the broadcast.
 
                     Example: `1356998400070`
-                  schema:
-                    type: integer
-                    minimum: 1356998400070
+                  minimum: 1356998400070
                 official:
                   type: boolean
                   description: For Lichess internal usage only. You are not allowed to use this flag. If you do it, we will have to call the police.
@@ -2436,9 +2434,7 @@ paths:
                       Timestamp in milliseconds of broadcast start. Leave empty to manually start the broadcast.
 
                       Example: `1356998400070`
-                    schema:
-                      type: integer
-                      minimum: 1356998400070
+                    minimum: 1356998400070
                   official:
                     type: boolean
                     description: For Lichess internal usage only. You are not allowed to use this flag. If you do it, we will have to call the police.

--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -174,6 +174,11 @@ paths:
       responses:
         200:
           description: The list of users and their respective statuses.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -222,8 +227,7 @@ paths:
       summary: Get all top 10
       tags:
         - Users
-      security:
-        - SameOrigin: []
+      security: []
       description: |
         Get the top 10 players for each speed and variant.
 
@@ -244,8 +248,7 @@ paths:
       summary: Get one leaderboard
       tags:
         - Users
-      security:
-        - SameOrigin: []
+      security: []
       description: |
         Get the leaderboard for a single speed or variant (a.k.a. `perfType`).
         There is no leaderboard for correspondence or puzzles.
@@ -286,6 +289,11 @@ paths:
       responses:
         200:
           description: The list of top players for the variant.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/vnd.lichess.v3+json:
               schema:
@@ -309,6 +317,11 @@ paths:
       responses:
         200:
           description: The information of the user.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -335,6 +348,11 @@ paths:
       responses:
         200:
           description: The rating history of the user.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -358,6 +376,11 @@ paths:
       responses:
         200:
           description: The activity feed of the user.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               example:
@@ -375,6 +398,11 @@ paths:
       responses:
         200:
           description: The daily puzzle.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/x-ndjson:
               schema:
@@ -406,6 +434,11 @@ paths:
       responses:
         200:
           description: The puzzle activity of the logged in user.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/x-ndjson:
               schema:
@@ -437,6 +470,11 @@ paths:
       responses:
         200:
           description: The puzzle dashboard of the logged in user.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -473,6 +511,11 @@ paths:
       responses:
         200:
           description: The storm dashboard of a player.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -500,6 +543,11 @@ paths:
       responses:
         200:
           description: The list of users.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -521,6 +569,11 @@ paths:
       responses:
         200:
           description: The public informations about the logged in user.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -540,6 +593,11 @@ paths:
       responses:
         200:
           description: The email address of the logged in user.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -566,6 +624,11 @@ paths:
       responses:
         200:
           description: The preferences of the logged in user.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -589,6 +652,11 @@ paths:
       responses:
         200:
           description: The kid mode status of the logged in user.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -620,6 +688,11 @@ paths:
       responses:
         200:
           description: The kid mode status was set successfully for the logged in user.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -707,6 +780,11 @@ paths:
       responses:
         200:
           description: The game representation.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/x-chess-pgn:
               schema:
@@ -796,6 +874,11 @@ paths:
       responses:
         200:
           description: The ongoing (or last) game of a user.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/x-chess-pgn:
               schema:
@@ -966,6 +1049,11 @@ paths:
       responses:
         200:
           description: The games of the user.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/x-chess-pgn:
               schema:
@@ -990,8 +1078,7 @@ paths:
         Ongoing games have their last 3 moves omitted, after move 5.
       tags:
         - Games
-      security:
-        - SameOrigin: []
+      security: []
       requestBody:
         description: Game IDs separated by commas. Up to 300.
         required: true
@@ -1091,6 +1178,11 @@ paths:
       responses:
         200:
           description: The stream of the games played between the users.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/x-ndjson:
               schema:
@@ -1121,6 +1213,11 @@ paths:
       responses:
         200:
           description: The ongoing games of the logged in user.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -1141,6 +1238,11 @@ paths:
       responses:
         200:
           description: The list of games being played for each speed and variant.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -1157,8 +1259,7 @@ paths:
         Try it with `curl https://lichess.org/api/tv/feed`.
       tags:
         - Games
-      security:
-        - SameOrigin: []
+      security: []
       responses:
         200:
           description: The stream of the current TV game.
@@ -1197,6 +1298,11 @@ paths:
       responses:
         200:
           description: The game was successfully imported.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -1216,6 +1322,11 @@ paths:
       responses:
         200:
           description: The list of current tournaments.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -1368,6 +1479,11 @@ paths:
       responses:
         200:
           description: The Arena tournament has been successfully created.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -1407,6 +1523,11 @@ paths:
       responses:
         200:
           description: The information of the Arena tournament.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -1549,6 +1670,11 @@ paths:
       responses:
         200:
           description: The Arena tournament was successfully updated.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -1603,6 +1729,11 @@ paths:
         responses:
           200:
             description: The team battle tournament was successfully updated.
+            headers:
+              Access-Control-Allow-Origin:
+                schema:
+                  type: string
+                  default: "'*'"
             content:
               application/json:
                 schema:
@@ -1680,6 +1811,11 @@ paths:
       responses:
         200:
           description: The list of games of an Arena tournament.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/x-chess-pgn:
               schema:
@@ -1719,6 +1855,11 @@ paths:
       responses:
         200:
           description: The results of the Arena tournament.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/x-ndjson:
               schema:
@@ -1743,6 +1884,11 @@ paths:
       responses:
         200:
           description: The list of teams of a team battle tournament, with their respective top players.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -1771,6 +1917,11 @@ paths:
       responses:
         200:
           description: The list of tournaments created by the user.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/x-ndjson:
               schema:
@@ -1875,6 +2026,11 @@ paths:
       responses:
         200:
           description: The Swiss tournament was successfully created.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -1909,6 +2065,11 @@ paths:
       responses:
         200:
           description: The TRF representation of a Swiss tournament.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             text/plain:
               example:
@@ -1979,6 +2140,11 @@ paths:
       responses:
         200:
           description: The list of games of a Swiss tournament.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/x-chess-pgn:
               schema:
@@ -2018,6 +2184,11 @@ paths:
       responses:
         200:
           description: The results of a Swiss tournament.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/x-ndjson:
               schema:
@@ -2054,6 +2225,11 @@ paths:
       responses:
         200:
           description: The list of Swiss tournaments of a team.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -2069,8 +2245,7 @@ paths:
         Download one study chapter in PGN format.
       tags:
         - Studies
-      security:
-        - SameOrigin: []
+      security: []
       parameters:
         - in: path
           name: studyId
@@ -2127,8 +2302,7 @@ paths:
         Download all chapters of a study in PGN format.
       tags:
         - Studies
-      security:
-        - SameOrigin: []
+      security: []
       parameters:
         - in: path
           name: studyId
@@ -2186,7 +2360,6 @@ paths:
         - OAuth
       security:
         - OAuth2: []
-        - SameOrigin: []
       parameters:
         - in: path
           name: username
@@ -2251,6 +2424,11 @@ paths:
       responses:
         200:
           description: The list of official broadcasts.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -2321,6 +2499,11 @@ paths:
       responses:
         200:
           description: The broadcast was successfully created.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -2344,7 +2527,6 @@ paths:
         - OAuth
       security:
         - OAuth2: ["study:read"]
-          SameOrigin: []
       parameters:
         - in: path
           name: slug
@@ -2447,6 +2629,11 @@ paths:
         responses:
           200:
             description: The broadcast was successfully edited.
+            headers:
+              Access-Control-Allow-Origin:
+                schema:
+                  type: string
+                  default: "'*'"
             content:
               application/json:
                 schema:
@@ -2470,7 +2657,6 @@ paths:
         - OAuth
       security:
         - OAuth2: ["study:write"]
-          SameOrigin: []
       parameters:
         - in: path
           name: slug
@@ -2495,6 +2681,11 @@ paths:
       responses:
         200:
           description: The broadcast was successfully updated.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -2514,6 +2705,11 @@ paths:
       responses:
         200:
           description: The list of simuls.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -2538,6 +2734,11 @@ paths:
       responses:
         200:
           description: The information about the team.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -2562,6 +2763,11 @@ paths:
       responses:
         200:
           description: A paginated list of the most popular teams.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -2588,6 +2794,11 @@ paths:
       responses:
         200:
           description: The list of teams the user is a member of.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -2619,6 +2830,11 @@ paths:
       responses:
         200:
           description: The paginated list of teams.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -2648,6 +2864,11 @@ paths:
       responses:
         200:
           description: The list of users in the team.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/x-ndjson:
               schema:
@@ -2684,6 +2905,11 @@ paths:
       responses:
         200:
           description: The list of Arena tournaments of a team.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -2706,7 +2932,6 @@ paths:
         - OAuth
       security:
         - OAuth2: ["team:write"]
-          SameOrigin: []
       parameters:
         - in: path
           name: teamId
@@ -2747,7 +2972,6 @@ paths:
         - OAuth
       security:
         - OAuth2: ["team:write"]
-          SameOrigin: []
       parameters:
         - in: path
           name: teamId
@@ -2775,7 +2999,6 @@ paths:
         - OAuth
       security:
         - OAuth2: ["team:write"]
-          SameOrigin: []
       parameters:
         - in: path
           name: teamId
@@ -2829,6 +3052,11 @@ paths:
       responses:
         200:
           description: The message has successfully been sent to all team members.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -2851,8 +3079,7 @@ paths:
         So you can call it quite often (like once every 5 seconds).
       tags:
         - Users
-      security:
-        - SameOrigin: []
+      security: []
       responses:
         200:
           description: The list of live streamers and their respective information.
@@ -2920,6 +3147,11 @@ paths:
       responses:
         200:
           description: The crosstable of the two users.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -2944,6 +3176,11 @@ paths:
       responses:
         200:
           description: The list of users followed by a user.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/x-ndjson:
               schema:
@@ -2968,6 +3205,11 @@ paths:
       responses:
         200:
           description: The list of users who follow a user.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/x-ndjson:
               schema:
@@ -2995,6 +3237,11 @@ paths:
       responses:
         200:
           description: The stream of events reaching the logged in user.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             text/plain:
               example: |
@@ -3075,6 +3322,11 @@ paths:
       responses:
         200:
           description: The seek was successfully created.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             text/plain:
               example: ""
@@ -3111,6 +3363,11 @@ paths:
       responses:
         200:
           description: The stream of the game.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -3156,6 +3413,11 @@ paths:
       responses:
         200:
           description: The move was successfully made.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -3205,6 +3467,11 @@ paths:
       responses:
         200:
           description: The message was successfully posted in the chat.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -3236,6 +3503,11 @@ paths:
       responses:
         200:
           description: The game successfully aborted.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -3267,6 +3539,11 @@ paths:
       responses:
         200:
           description: The game was successfully resigned.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -3306,6 +3583,11 @@ paths:
       responses:
         200:
           description: The draw offer was successfully sent.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -3339,6 +3621,11 @@ paths:
       responses:
         200:
           description: The bot account was successfully upgraded.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -3376,6 +3663,11 @@ paths:
       responses:
         200:
           description: The stream of the bot game.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -3421,6 +3713,11 @@ paths:
       responses:
         200:
           description: The bot move was successfully made.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -3470,6 +3767,11 @@ paths:
       responses:
         200:
           description: The message was successfully posted in chat.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -3501,6 +3803,11 @@ paths:
       responses:
         200:
           description: The game was successfully aborted.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -3532,6 +3839,11 @@ paths:
       responses:
         200:
           description: The game was successfully resigned from.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -3644,6 +3956,11 @@ paths:
       responses:
         200:
           description: The challenge was successfully created.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -3677,6 +3994,11 @@ paths:
       responses:
         200:
           description: The challenge was successfully accepted.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -3731,6 +4053,11 @@ paths:
       responses:
         200:
           description: The challenge was successfully declined.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -3763,6 +4090,11 @@ paths:
       responses:
         200:
           description: The challenge was successfully cancelled.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -3846,6 +4178,11 @@ paths:
       responses:
         200:
           description: The game with Lichess AI was successfully started.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -3924,6 +4261,11 @@ paths:
       responses:
         200:
           description: The challenge was successfully created.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -3969,6 +4311,11 @@ paths:
       responses:
         200:
           description: The clock of a game was successfully started.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -3991,6 +4338,11 @@ paths:
       responses:
         200:
           description: The list of upcoming bulk pairing the logged in user created.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -4104,6 +4456,11 @@ paths:
       responses:
         200:
           description: The bulk pairings have been successfully created.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -4142,6 +4499,11 @@ paths:
       responses:
         200:
           description: The clocks of the games of a bulk pairing were successfully started.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -4178,6 +4540,11 @@ paths:
       responses:
         200:
           description: The bulk pairing was successfully deleted.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -4218,6 +4585,11 @@ paths:
       responses:
         200:
           description: Time was successfully added to the opponent's clock.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -4319,6 +4691,11 @@ paths:
       responses:
         200:
           description: The challenge has been successfully created.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -4340,7 +4717,6 @@ paths:
         - Messaging
       security:
         - OAuth2: ["msg:write"]
-          SameOrigin: []
       parameters:
         - in: path
           name: username
@@ -4410,6 +4786,11 @@ paths:
       responses:
         200:
           description: The evaluation of the position.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               example: {"fen":"rnbqkbnr/ppp1pppp/8/3pP3/8/8/PPPP1PPP/RNBQKBNR b KQkq - 0 2","knodes":13683,"depth":22,"pvs":[{"moves":"c8f5 d2d4 e7e6 g1f3 g8e7 c1e3 c7c5 d4c5 e7c6 b1c3","cp":-13},{"moves":"c7c5 c2c3 d5d4 g1f3 b8c6 c3d4 c6d4 b1c3 c8d7 f1d3","cp":-1},{"moves":"e7e6 d2d4 c7c5 c2c3 b8c6 g1f3 c8d7 b1a3 c5d4 c3d4","cp":24}]}
@@ -4457,6 +4838,11 @@ paths:
       responses:
         200:
           description: The evaluation of the position.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -4545,6 +4931,11 @@ paths:
       responses:
         200:
           description: The list of openings.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -4570,6 +4961,11 @@ paths:
       responses:
         200:
           description: The PGN representation of the game.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/x-chess-pgn:
               schema:
@@ -4589,6 +4985,11 @@ paths:
       responses:
         200:
           description: The statistics of the Opening Explorer.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               example: {"master":{"games":2299868,"uniquePositions":56683918},"lichess":{"chess960":{"games":2259840,"uniquePositions":190488295},"standard":{"games":272515941,"uniquePositions":7355380242},"antichess":{"games":7818476,"uniquePositions":177073596},"horde":{"games":1027171,"uniquePositions":34843126},"atomic":{"games":3827483,"uniquePositions":70119949},"racingKings":{"games":747878,"uniquePositions":11671677},"kingOfTheHill":{"games":1345370,"uniquePositions":38511395},"crazyhouse":{"games":7540244,"uniquePositions":218945811},"threeCheck":{"games":1362591,"uniquePositions":29181473}}}
@@ -4613,6 +5014,11 @@ paths:
       responses:
         200:
           description: The tablebase information for the position in standard chess.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
           content:
             application/json:
               schema:
@@ -4626,6 +5032,11 @@ paths:
       responses:
         200:
           description: The tablebase information for the position in atomic chess.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
 
   /antichess:
     get:
@@ -4636,6 +5047,11 @@ paths:
       responses:
         200:
           description: The tablebase information for the position in atomic chess.
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+                default: "'*'"
 
 
 components:
@@ -6129,9 +6545,3 @@ components:
             "msg:write": Send private messages to other players
             "board:play": Play with the Board API
             "bot:play": Play with the Bot API. Only for [Bot accounts](#operation/botAccountUpgrade)
-    SameOrigin:
-      description: "CORS is supported on almost all endpoints, except those tagged `SameOrigin`.\n\
-        \ If you need CORS on one of those, please\n\
-        \ [make an issue](https://github.com/ornicar/lila/issues/new)\n\
-        \ explaining your use case to request it."
-      type: none

--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -4627,6 +4627,9 @@ paths:
       summary: Tablebase lookup for Atomic chess
       tags:
         - Tablebase
+      responses:
+        200:
+          description: The tablebase information for the position in atomic chess.
 
   /antichess:
     get:
@@ -4634,6 +4637,9 @@ paths:
       summary: Tablebase lookup for Antichess
       tags:
         - Tablebase
+      responses:
+        200:
+          description: The tablebase information for the position in atomic chess.
 
 
 components:


### PR DESCRIPTION
Fixes #11!

`openapi-generator-cli validate -i doc/specs/lichess-api.yaml` gives the remaining spec violations.

Signed-off-by: Pamplemousse <xav.maso@gmail.com>