### PR TITLE
ongoing games cannot be exported

### DIFF
--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -1046,12 +1046,6 @@ paths:
             type: boolean
             default: null
         - in: query
-          name: ongoing
-          description: "[Filter] Also include ongoing games"
-          schema:
-            type: boolean
-            default: false
-        - in: query
           name: moves
           description: Include the PGN moves.
           schema:


### PR DESCRIPTION
Remove "ongoing" query parameter from documentation of
/api/games/user/{username} endpoint,
since it is no longer used:

https://github.com/ornicar/lila/commit/2bdaa990