### PR TITLE
switch to `berserk-downstream`

### DIFF
--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -18,7 +18,7 @@ info:
     All requests go to `https://lichess.org` (unless otherwise specified).
 
     ## Clients
-    - [Python general API](https://github.com/rhgrant10/berserk)
+    - [Python general API](https://github.com/ZackClements/berserk)
     - [MicroPython general API](https://github.com/mkomon/uberserk)
     - [Python general API - async](https://pypi.org/project/async-lichess-sdk)
     - [Python Lichess Bot](https://github.com/careless25/lichess-bot)


### PR DESCRIPTION
`berserk` is no longer maintained and does not work reliably anymore.