### PR TITLE
Fix documentation publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,5 +31,5 @@ jobs:
     - name: GitHub pages deploy
       uses: maxheld83/ghpages@68f783a4f5313d776c1599e18479607e71c9c738
       env:
-        BUILD_DIR: "public/"
+        BUILD_DIR: "doc/public/"
         GH_PAT: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
Fixes error introduced in #134. It was not caught in staging because it was never run on `upstream/master`.