### PR TITLE
Add link to Java client

### DIFF
--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -23,6 +23,7 @@ info:
     - [Python general API - async](https://pypi.org/project/async-lichess-sdk)
     - [Python Lichess Bot](https://github.com/careless25/lichess-bot)
     - [Python Board API for Certabo](https://github.com/haklein/certabo-lichess)
+    - [Java general API](https://github.com/tors42/chariot)
 
     ## Rate limiting
     All requests are rate limited using various strategies,


### PR DESCRIPTION
Maybe some Java developers could be interested in using this Java 17 library to access the Lichess API.
https://github.com/tors42/chariot