### PR TITLE
Move dot into string

### DIFF
--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -1115,7 +1115,7 @@ paths:
             type: string
         - in: query
           name: sort
-          description: "Sort order of the games".
+          description: "Sort order of the games."
           schema:
             type: string
             default: dateDesc


### PR DESCRIPTION
`npm run serve -- --watch` fails when the dot is outside of the string:
Error while updating:  can not read a block mapping entry; a multiline key may not be an implicit key in "lichess-org/api/doc/specs/lichess-api.yaml" at line 1119, column 17

Moving it into the string, it gets much happier and responds with "Updated successfully",
woop woop!

