### PR TITLE
fix: correct /streamer/live return type

### DIFF
--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -3952,18 +3952,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                    name:
-                      type: string
-                    title:
-                      type: [string, 'null']
-                    online:
-                      type: [boolean, 'null']
-                    patron:
-                      type: [boolean, 'null']
+                  $ref: '#/components/schemas/LightUser'
                 example: [
                   {
                     "id": "aliquantus",
@@ -3973,7 +3962,6 @@ paths:
                     "id": "chess-network",
                     "name": "Chess-Network",
                     "title": "NM",
-                    "playing": true,
                     "patron": true
                   }
                 ]


### PR DESCRIPTION
The docs currently state that the objects returned by the `/streamer/live` endpoint have fields `id`, `name`, `title`, `online`, and `patron`, but based on [lila.app.controller.Streamer](https://github.com/ornicar/lila/blob/53bc7d78fbea4dbb7ff3ebd62ace17d8a0046955/app/controllers/Streamer.scala#L53-L63) the objects which are returned are of type `LightUser`, which have no `online` field. This PR switches `/streamer/live` to using the `LightUser` schema accordingly. Examples were fixed appropriately.