### PR TITLE
Add missing `standard` and `puzzle` perf types to API spec

### DIFF
--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -6663,6 +6663,7 @@ components:
         - blitz
         - rapid
         - classical
+        - standard
         - correspondence
         - chess960
         - crazyhouse
@@ -6672,6 +6673,7 @@ components:
         - kingOfTheHill
         - racingKings
         - threeCheck
+        - puzzle
 
     Clock:
       type: object


### PR DESCRIPTION
See https://github.com/lichess-org/lila/blob/master/modules/rating/src/main/PerfType.scala#L170