### PR TITLE
Adding updated Python wrapper for Lichess API

### DIFF
--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -23,6 +23,7 @@ info:
     All requests go to `https://lichess.org` (unless otherwise specified).
 
     ## Clients
+    - [Python API (Updated)](https://github.com/qe/lichess)
     - [Python general API](https://github.com/ZackClements/berserk)
     - [MicroPython general API](https://github.com/mkomon/uberserk)
     - [Python general API - async](https://pypi.org/project/async-lichess-sdk)


### PR DESCRIPTION
This Python API wrapper is up to date with the newest endpoints of the Lichess API and has the majority of the functionalities. At the moment, it only takes up [~38 kB](https://img.shields.io/github/languages/code-size/qe/lichess). Its documentation is on the GitHub repo, but I will also link it [here](https://lichess-api.readthedocs.io/) . Will be finishing adding all the endpoints and categories of the API very soon. 

Please let me know if you have any questions or concerns, thank you!