### PR TITLE
Clarify MoveStream API

### DIFF
--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -8862,6 +8862,7 @@ components:
           "createdAt": 1620029815106,
           "lastMove": "c7c5"
         },
+        { "fen": "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w", "wc": 180, "bc": 180 },
         { "fen": "rnbqkbnr/pppppppp/8/8/8/4P3/PPPP1PPP/RNBQKBNR b", "lm": "e2e3", "wc": 180, "bc": 180 },
         { "fen": "rnbqkb1r/pppppppp/7n/8/8/4P3/PPPP1PPP/RNBQKBNR w", "lm": "g8h6", "wc": 180, "bc": 180 },
         {

--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -1357,7 +1357,7 @@ paths:
         Stream positions and moves of any ongoing game, in [ndjson](#section/Introduction/Streaming-with-ND-JSON).
 
         A description of the game is sent as a first message.
-        Then a message is sent each time a move is played.
+        Then a message is sent each time a move is played indicating the board state, the last move, and the current time remaining for each side. For standard games, the state updates start from the very first move. For variants, the state updates start from the state of the board when the request was sent.
         Finally a description of the game is sent when it finishes, and the stream is closed.
 
         After move 5, the stream intentionally remains 3 moves behind the game status, as to prevent cheat bots from using this API.
@@ -8862,7 +8862,6 @@ components:
           "createdAt": 1620029815106,
           "lastMove": "c7c5"
         },
-        { "fen": "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w", "wc": 180, "bc": 180 },
         { "fen": "rnbqkbnr/pppppppp/8/8/8/4P3/PPPP1PPP/RNBQKBNR b", "lm": "e2e3", "wc": 180, "bc": 180 },
         { "fen": "rnbqkb1r/pppppppp/7n/8/8/4P3/PPPP1PPP/RNBQKBNR w", "lm": "g8h6", "wc": 180, "bc": 180 },
         {

--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -1357,7 +1357,7 @@ paths:
         Stream positions and moves of any ongoing game, in [ndjson](#section/Introduction/Streaming-with-ND-JSON).
 
         A description of the game is sent as a first message.
-        Then a message is sent each time a move is played indicating the board state, the last move, and the current time remaining for each side. For standard games, the state updates start from the very first move. For variants, the state updates start from the state of the board when the request was sent.
+        Then a message is sent each time a move is played indicating the board state, the last move, and the current time remaining for each side. For game types other than Horde and Racing Kings, the state updates start from the very first move. For Horde and Racing Kings, the state updates start from the state of the board when the request was sent.
         Finally a description of the game is sent when it finishes, and the stream is closed.
 
         After move 5, the stream intentionally remains 3 moves behind the game status, as to prevent cheat bots from using this API.


### PR DESCRIPTION
Clarifies the MoveStream API documentation to describe the structure of the updates and a difference in behavior with some variants.

I also removed one of the messages in the example for this API call, as the initial game state with no move is never sent as an update.

-----------------------------------------------

Two small notes, will open issues about them unless I am advised against it here:

1) It seems Horde and Racing Kings's game updates start from the current position rather than the starting position. Is this on purpose? Actually I can't tell exactly why this is the case from reading the code, but it seems to only be games that have `standardInitialPosition = false` (except that Chess960 works as expected).

2) Standard games only show the complete fen at the start and end of games in the updates. However, the complete fen is known at all times. IMO it should be displayed at all times so that the user does not have to manually track the true fen. I believe it just this line needs to be changed to include the castle info:

https://github.com/lichess-org/lila/blob/6067f0c1d61d275925849c5057f0e6aef6bee58e/modules/round/src/main/ApiMoveStream.scala#L94-L106

^ this link preview isn't displaying correctly, so I have reproduced it here: 

```javascript
  private def toJson(
      boardFen: String,
      turnColor: Color,
      lastMoveUci: Option[String],
      clock: Option[(Centis, Centis)]
  ): JsObject =
    clock.foldLeft(
      Json
        .obj("fen" -> s"$boardFen ${turnColor.letter}")
        .add("lm" -> lastMoveUci)
    ) { case (js, clk) =>
      js ++ Json.obj("wc" -> clk._1.roundSeconds, "bc" -> clk._2.roundSeconds)
    }
}
```