### PR TITLE
Add OAuthError schema and reference it in the doc of `token` endpoint

### DIFF
--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -6213,7 +6213,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/OAuthError'
     delete:
       operationId: apiTokenDelete
       summary: Revoke access token
@@ -8880,6 +8880,18 @@ components:
           description: The cause of the error.
       example:
         error: "This request is invalid because [...]"
+
+    OAuthError:
+      properties:
+        error:
+          type: string
+          description: The cause of the error.
+        error_description:
+          type: string
+          description: The reason why the request was rejected.
+      example:
+        error: "invalid_grant"
+        error_description: "hash of code_verifier does not match code_challenge"
 
     NotFound:
       properties:


### PR DESCRIPTION
The 400 response of `api/token` contains two fields: `error` and `error_description`. 
Currently, only the `error` field in mentioned in the docs but the `error_description` field may contain usefull information for debugging. 

This PR creates a new schema for errors with an `error_description` field and use it in the documentation of the `api/token` endpoint