### PR TITLE
Endpoint operation/tvChannelGames path uses camel case

### DIFF
--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -1602,7 +1602,7 @@ paths:
       parameters:
         - in: path
           name: channel
-          description: The name of the channel in lowercase.
+          description: The name of the channel in camel case.
           schema:
             type: string
           required: true


### PR DESCRIPTION
Whether or not `https://lichess.org/api/tv/{channel}` should be using camel case, currently it only accepts camel case e.g. `https://lichess.org/api/tv/threeCheck`.