### PR TITLE
Add racer:write to scopes list

### DIFF
--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -8999,6 +8999,7 @@ components:
             "study:read": Read private studies and broadcasts
             "study:write": Create, update, delete studies and broadcasts
             "tournament:write": Create tournaments
+            "racer:write": Create and join puzzle races
             "puzzle:read": Read puzzle activity
             "team:read": Read private team information
             "team:write": Join, leave, and manage teams


### PR DESCRIPTION
The racer:write scope is specified for /api/racer endpoint,
but was missing from the list of scopes