### PR TITLE
Add docs for `literate` in `export games by ids`

### DIFF
--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -1252,6 +1252,15 @@ paths:
             type: boolean
             default: false
         - in: query
+          name: literate
+          description: |
+            Insert textual annotations in the PGN about the opening, analysis variations, mistakes, and game termination.
+
+            Example: `5... g4? { (-0.98 → 0.60) Mistake. Best move was h6. } (5... h6 6. d4 Ne7 7. g3 d5 8. exd5 fxg3 9. hxg3 c6 10. dxc6)`
+          schema:
+            type: boolean
+            default: false
+        - in: query
           name: players
           description: |
             URL of a text file containing real names and ratings, to replace Lichess usernames and ratings in the PGN.


### PR DESCRIPTION
`literate` is a valid flag in `gamesExportIds` (see [here](https://github.com/lichess-org/lila/blob/110d2b7bdb9fce6398c7aeff323b66660cf1ba8c/app/controllers/Game.scala#L177-L187)), but it is undocumented. This adds docs for the `literate` query parameter. 