### PR TITLE
Fix ExternalEngineRegistration

### DIFF
--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -9724,7 +9724,6 @@ components:
           description: Optional comma seperated list of supported chess variants.
           items:
             $ref: '#/components/schemas/VariantKey'
-          required: false
         #officialStockfish:
         #  type: boolean
         #  description: |


### PR DESCRIPTION
Remove required attribute in ExternalEngineRegistration because the `required` field is an object-level attribute, not a property attribute. It currently generates a wrong openapi.json file. See `"required": false` line 12763.