### PR TITLE
chore(README.md): MD034 Violation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ npm install
 npm run serve
 ```
 
-Now open http://localhost:8089/. You should see the generated API doc.
+Now open <http://localhost:8089/>. You should see the generated API doc.
 
 Make modifications to `doc/specs/lichess-api.yaml`, and reload the page to see your changes.


### PR DESCRIPTION
Rationale: Without angle brackets, a bare URL or email isn't converted into a link by some Markdown parsers.