### PR TITLE
fix(docs): remove `Get members of a team` on Users section

### DIFF
--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -4534,7 +4534,6 @@ paths:
 
         Members are streamed as [ndjson](#section/Introduction/Streaming-with-ND-JSON).
       tags:
-        - Users
         - Teams
       security:
         - OAuth2: ["team:read"]


### PR DESCRIPTION
### what & why

The examples are reachable per one section, but not `Get members of a team`.
The duplication of this on both Users and Teams is unnecessary.

Fixes #280 