### PR TITLE
Evals are not always included by default for game exports

### DIFF
--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -1236,7 +1236,7 @@ paths:
             Or in an `analysis` JSON field, depending on the response type.
           schema:
             type: boolean
-            default: true
+            default: false
         - in: query
           name: accuracy
           description: |
@@ -1378,7 +1378,7 @@ paths:
             Or in an `analysis` JSON field, depending on the response type.
           schema:
             type: boolean
-            default: true
+            default: false
         - in: query
           name: accuracy
           description: |
@@ -2554,7 +2554,7 @@ paths:
             Or in an `analysis` JSON field, depending on the response type.
           schema:
             type: boolean
-            default: true
+            default: false
         - in: query
           name: accuracy
           description: |
@@ -3440,7 +3440,7 @@ paths:
             Or in an `analysis` JSON field, depending on the response type.
           schema:
             type: boolean
-            default: true
+            default: false
         - in: query
           name: accuracy
           description: |


### PR DESCRIPTION
Affects multi-game exports where [requestPgnFlags](https://github.com/lichess-org/lila/blob/b82aaf55327f5c142375b50581b3761949eea7d4/app/controllers/Game.scala#L140) is called with `extended = false` for the following endpoints:

1. /api/games/user/{username} https://github.com/lichess-org/lila/blob/b82aaf55327f5c142375b50581b3761949eea7d4/app/controllers/Game.scala#L74
2. /api/games/export/_ids https://github.com/lichess-org/lila/blob/b82aaf55327f5c142375b50581b3761949eea7d4/app/controllers/Game.scala#L123
3. /api/tournament/{id}/games https://github.com/lichess-org/lila/blob/b82aaf55327f5c142375b50581b3761949eea7d4/app/controllers/Api.scala#L193
4. /api/swiss/{id}/games https://github.com/lichess-org/lila/blob/b82aaf55327f5c142375b50581b3761949eea7d4/app/controllers/Api.scala#L250

Default values for the other `extended` opts (`clock` and `opening`) are already correct