### PR TITLE
Remove chance of unexpected type coercion and remove unnecessary param to `TextEncoder`

### DIFF
--- a/doc/scripts/generate-code-samples.js
+++ b/doc/scripts/generate-code-samples.js
@@ -2,11 +2,10 @@
 // from https://github.com/Direct-Freight/df-api-docs/blob/master/scripts/generate-code-samples.js
 'use strict'
 require('shelljs/global');
-var fs = require('fs')
-var stringifyObject = require('stringify-object');
-var SwaggerSnippet = require('swagger-snippet')
+const fs = require('fs')
+const SwaggerSnippet = require('swagger-snippet')
 
-if(process.argv[2] != 'skip-pre-bundle')
+if(process.argv[2] !== 'skip-pre-bundle')
         {
         console.log("first bundle combined file to ensure it is up to date");
         exec('swagger-repo bundle -o ./web_deploy/swagger.json'); //this wants a single dot
@@ -45,19 +44,18 @@ var results = SwaggerSnippet.getSwaggerSnippets(SwaggerFile,
 
 results.forEach(function(result)
         {
-        var path = result.url.replace(/http.*api\//,'').replace(/\//g,'@');
-        const pretty = stringifyObject(result.snippets, { indent: '  ', singleQuotes: false });
+        const path = result.url.replace(/http.*api\//,'').replace(/\//g,'@');
         result.snippets.forEach(function(snippet)
                 {
-                var ext = '.txt';
-                var lang = snippet.id;
+                let ext = '.txt';
+                let lang = snippet.id;
                 lang = lang[0].toUpperCase() + lang.substring(1); //uppercase first letter
-                if(lang == 'Shell_curl') { ext = '.sh'; lang = 'curl'; }
-                if(lang == 'Shell_wget') { ext = '.sh'; lang = 'wget'; }
-                if(lang.substring(0,4) == 'Perl') { ext = '.pl'; }
-                if(lang.substring(0,6) == 'Python') { ext = '.py'; }
-                if(lang.substring(0,3) == 'Php') { ext = '.php'; }
-                var dir = 'spec/code_samples/' + lang + '/' + path + '/';
+                if(lang === 'Shell_curl') { ext = '.sh'; lang = 'curl'; }
+                if(lang === 'Shell_wget') { ext = '.sh'; lang = 'wget'; }
+                if(lang.substring(0,4) === 'Perl') { ext = '.pl'; }
+                if(lang.substring(0,6) === 'Python') { ext = '.py'; }
+                if(lang.substring(0,3) === 'Php') { ext = '.php'; }
+                const dir = 'spec/code_samples/' + lang + '/' + path + '/';
                 mkdir('-p',dir);
                 fs.writeFile(dir + result.method.toLowerCase() + ext,snippet.content, (err) => {
                         if (err)

--- a/example/tournament-entry-code/browser.js
+++ b/example/tournament-entry-code/browser.js
@@ -1,5 +1,5 @@
 async function hmacSha256(secret, data) {
-  const utf8 = new TextEncoder('utf-8');
+  const utf8 = new TextEncoder();
   const algorithm = {name: 'HMAC', hash: 'SHA-256'};
   const key = await crypto.subtle.importKey('raw', utf8.encode(secret), algorithm, false, ['sign']);
   return await crypto.subtle.sign(algorithm, key, utf8.encode(data));


### PR DESCRIPTION
In this PR:
- Use `===` instead of `==` and `!==` instead of `!=` as the latter may cause unexpected type coercion [[source](https://www.c-sharpcorner.com/article/avascript-type-coercion-explained-how-to-avoid-common-pitfalls/#:~:text=Type%20coercion%20occurs%20when%20values,and%20errors%20in%20your%20code.)].
- `TextEncoder` only supports `utf-8` and does not accept any input params [[source](https://javascript.info/text-decoder#textencoder)]. So we should declare it like `TextEncoder` instead of `TextEncoder('utf-8')`.
- Use `const`/`let` instead of `var` where appropriate.
- Remove `stringify-object` as it is unused because `pretty` is unused.