### PR TITLE
Error message should reference chapter, not swiss tournament

### DIFF
--- a/doc/specs/tags/studies/api-study-studyId-import-pgn.yaml
+++ b/doc/specs/tags/studies/api-study-studyId-import-pgn.yaml
@@ -61,7 +61,7 @@ post:
           schema:
             $ref: '../../schemas/StudyImportPgnChapters.yaml'
     "400":
-      description: The creation of the Swiss tournament failed.
+      description: The creation of the chapter(s) failed.
       content:
         application/json:
           schema:


### PR DESCRIPTION
"Import PGN into a study" was using same 400 error message as creating a Swiss tournament.