### PR TITLE
Fix a typo in the antichess tablebase api documentation

### DIFF
--- a/doc/specs/tags/tablebase/antichess.yaml
+++ b/doc/specs/tags/tablebase/antichess.yaml
@@ -10,7 +10,7 @@ get:
   security: []
   responses:
     "200":
-      description: The tablebase information for the position in atomic chess.
+      description: The tablebase information for the position in antichess.
       content:
         text/plain:
           schema:


### PR DESCRIPTION
Fix the description, which previously referred to atomic chess instead of antichess