### PR TITLE
fixes BOT title in bots online endpoint 

### DIFF
--- a/doc/specs/schemas/BotTitle.yaml
+++ b/doc/specs/schemas/BotTitle.yaml
@@ -1,0 +1,2 @@
+type: string
+example: BOT

--- a/doc/specs/schemas/BotUser.yaml
+++ b/doc/specs/schemas/BotUser.yaml
@@ -1,0 +1,36 @@
+type: object
+properties:
+  id:
+    type: string
+    example: georges-bot
+  username:
+    type: string
+    example: Georges-bot
+  perfs:
+    $ref: './Perfs.yaml'
+  createdAt:
+    type: integer
+    format: int64
+    example: 1290415680000
+  disabled:
+    type: boolean
+    example: false
+  tosViolation:
+    type: boolean
+    example: false
+  profile:
+    $ref: './Profile.yaml'
+  seenAt:
+    type: integer
+    format: int64
+    example: 1522636452014
+  patron:
+    type: boolean
+    example: true
+  verified:
+    type: boolean
+    example: true
+  playTime:
+    $ref: './PlayTime.yaml'
+  title:
+    $ref: './BotTitle.yaml'

--- a/doc/specs/tags/bot/api-bot-online.yaml
+++ b/doc/specs/tags/bot/api-bot-online.yaml
@@ -24,4 +24,4 @@ get:
       content:
         application/x-ndjson:
           schema:
-            $ref: '../../schemas/User.yaml'
+            $ref: '../../schemas/BotUser.yaml'


### PR DESCRIPTION
fixes #243 task 3 adding bot user in Bot title and id containing bot in ID and user to make it easy to understand as previous response fields were confusing 