### PR TITLE
Add Redocly linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,4 +15,5 @@ jobs:
       with:
         node-version: 20
     - run: npm ci
+    - run: npm run spectral
     - run: npm run lint

--- a/README.md
+++ b/README.md
@@ -19,5 +19,6 @@ Make modifications to `doc/specs/lichess-api.yaml`, and reload the page to see y
 ### Check the yaml files for syntax errors:
 
 ```shell
+npm run spectral
 npm run lint
 ```

--- a/doc/package.json
+++ b/doc/package.json
@@ -7,7 +7,8 @@
     "@stoplight/spectral-cli": "^6.11.1"
   },
   "scripts": {
-    "lint": "spectral lint --fail-severity=warn specs/*.yaml",
+    "spectral": "spectral lint --fail-severity=warn specs/*.yaml",
+    "lint": "npx @redocly/cli lint specs/lichess-api.yaml",
     "build": "npx @redocly/cli build-docs specs/lichess-api.yaml --output public/index.html",
     "serve": "npx @redocly/cli preview-docs specs/lichess-api.yaml --port 8089"
   }

--- a/doc/redocly.yaml
+++ b/doc/redocly.yaml
@@ -1,3 +1,9 @@
 theme:
   openapi:
     htmlTemplate: ./template.hbs
+
+extends:
+  - recommended
+
+rules:
+  operation-4xx-response: off

--- a/doc/specs/schemas/BroadcastPgnPush.yaml
+++ b/doc/specs/schemas/BroadcastPgnPush.yaml
@@ -2,17 +2,12 @@ type: object
 properties:
   games:
     type: array
-    item:
-      oneOf:
-        - type: object
-          properties:
-            tags:
-              type: object
-            moves:
-              type: integer
-        - type: object
-          properties:
-            tags:
-              type: object
-            error:
-              type: string
+    items:
+      type: object
+      properties:
+        tags:
+          type: object
+        moves:
+          type: integer
+        error:
+          type: string

--- a/doc/specs/tags/broadcasts/api-broadcast-broadcastTournamentSlug-broadcastRoundSlug-broadcastRoundId.yaml
+++ b/doc/specs/tags/broadcasts/api-broadcast-broadcastTournamentSlug-broadcastRoundSlug-broadcastRoundId.yaml
@@ -5,6 +5,7 @@ get:
     Get information about a broadcast round.
   tags:
     - Broadcasts
+  security: []
   parameters:
     - in: path
       name: broadcastTournamentSlug

--- a/doc/specs/tags/broadcasts/broadcast-broadcastTournamentId-leaderboard.yaml
+++ b/doc/specs/tags/broadcasts/broadcast-broadcastTournamentId-leaderboard.yaml
@@ -5,6 +5,7 @@ get:
     Get the leaderboard of a broadcast tournament, if available.
   tags:
     - Broadcasts
+  security: []
   parameters:
     - in: path
       name: broadcastTournamentId

--- a/doc/specs/tags/broadcasts/broadcast-broadcastTournamentId.yaml
+++ b/doc/specs/tags/broadcasts/broadcast-broadcastTournamentId.yaml
@@ -5,6 +5,7 @@ get:
     Get information about a broadcast tournament.
   tags:
     - Broadcasts
+  security: []
   parameters:
     - in: path
       name: broadcastTournamentId


### PR DESCRIPTION
Redocly CLI now has a [linter](https://redocly.com/docs/cli/commands/lint/).

This PR fixes the errors that it found and configures the Github Action to use it.