### PR TITLE
Generate static "bundled" openapi yaml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: npm ci
       - run: npm run build
+      - run: npm run bundle
       - uses: actions/configure-pages@v3
       - uses: actions/upload-pages-artifact@v2
         with:

--- a/doc/package.json
+++ b/doc/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "spectral": "spectral lint --fail-severity=warn specs/*.yaml",
     "lint": "npx @redocly/cli lint specs/lichess-api.yaml",
+    "bundle": "npx @redocly/cli bundle specs/lichess-api.yaml --output public/openapi.yaml",
     "build": "npx @redocly/cli build-docs specs/lichess-api.yaml --output public/index.html",
     "serve": "npx @redocly/cli preview-docs specs/lichess-api.yaml --port 8089"
   }


### PR DESCRIPTION
This makes it possible to reference the openapi specification with a link, in addition to having the JavaScript "Download" button of redocly.

"Bundled" == $ref:s are resolved