### PR TITLE
Update min/max seconds for add-time

### DIFF
--- a/doc/specs/tags/challenges/api-round-gameId-add-time-seconds.yaml
+++ b/doc/specs/tags/challenges/api-round-gameId-add-time-seconds.yaml
@@ -19,8 +19,8 @@ post:
       description: How many seconds to give
       schema:
         type: string
-        minimum: 1
-        maximum: 86400
+        minimum: 5
+        maximum: 60
       required: true
   responses:
     "200":


### PR DESCRIPTION
min     1 ->  5
max 86400 -> 60

Trying to give 1 second results in 5 seconds.
Trying to give 86400 results in 60 seconds.

(Which corresponds to what can be found in
https://github.com/lichess-org/lila/blob/8dec1e4c8223483b29e95638ceed56365dbd4a66/modules/round/src/main/Moretimer.scala#L16-L17
```scala
 private val minTime = 5.seconds
 private val maxTime = 60.seconds
```
)