### PR TITLE
Fix Swiss "position" documentation

### DIFF
--- a/doc/specs/schemas/SwissFromPositionFEN.yaml
+++ b/doc/specs/schemas/SwissFromPositionFEN.yaml
@@ -1,0 +1,3 @@
+type: string
+description: Custom initial position (in FEN). Variant must be standard and the game cannot be rated.
+default: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1'

--- a/doc/specs/tags/swisstournaments/api-swiss-id-edit.yaml
+++ b/doc/specs/tags/swisstournaments/api-swiss-id-edit.yaml
@@ -113,6 +113,8 @@ post:
                 - 99999999
             variant:
               $ref: '../../schemas/VariantKey.yaml'
+            position:
+              $ref: '../../schemas/SwissFromPositionFEN.yaml'
             description:
               type: string
               description: Anything you want to tell players about the tournament

--- a/doc/specs/tags/swisstournaments/api-swiss-new-teamId.yaml
+++ b/doc/specs/tags/swisstournaments/api-swiss-new-teamId.yaml
@@ -114,7 +114,7 @@ post:
             variant:
               $ref: '../../schemas/VariantKey.yaml'
             position:
-              $ref: '../../schemas/FromPositionFEN.yaml'
+              $ref: '../../schemas/SwissFromPositionFEN.yaml'
             description:
               type: string
               description: Anything you want to tell players about the tournament


### PR DESCRIPTION
In Swiss tournaments,
specifying "position" is only allowed for "standard" variant.

( Related outdated PR https://github.com/lichess-org/lila/pull/15920 , which tried to change the rules instead of the documentation :sweat_smile: )