### PR TITLE
Chore / Restore color property from seek api

### DIFF
--- a/doc/specs/tags/board/api-board-seek.yaml
+++ b/doc/specs/tags/board/api-board-seek.yaml
@@ -58,6 +58,14 @@ post:
                     example: 15
                     minimum: 0
                     maximum: 180
+                  color:
+                    type: string
+                    description: The color to play. Better left empty to automatically get 50% white.
+                    enum:
+                      - random
+                      - white
+                      - black
+                    default: random
               - type: object
                 title: correspondence
                 required:


### PR DESCRIPTION
Closes #407 

It restore the `color` property to the Seek API, just in the case of NOT `correspondence`.


https://github.com/user-attachments/assets/ca8ef996-3e35-4f11-b3f4-9e56c6aea649

