### PR TITLE
Update schema for adding/editing broadcast round

### DIFF
--- a/doc/specs/schemas/BroadcastRoundForm.yaml
+++ b/doc/specs/schemas/BroadcastRoundForm.yaml
@@ -147,11 +147,15 @@ allOf:
           Example: `900` (15 min)
         minimum: 0
         maximum: 3600
-      finished:
-        type: boolean
+      status:
+        type: string
+        enum:
+          - new
+          - started
+          - finished
         description: |
-          Mark whether the round has been completed.
-        default: false
+          Lichess can usually detect the round status, but you can also set it manually if needed.
+        default: new
       period:
         type: integer
         description: |

--- a/doc/specs/tags/broadcasts/broadcast-broadcastTournamentId-edit.yaml
+++ b/doc/specs/tags/broadcasts/broadcast-broadcastTournamentId-edit.yaml
@@ -35,7 +35,7 @@ post:
           schema:
             $ref: '../../schemas/Ok.yaml'
     "400":
-      description: The edition of the broadcast tournament failed.
+      description: The broadcast tournament update failed.
       content:
         application/json:
           schema:

--- a/doc/specs/tags/broadcasts/broadcast-round-broadcastRoundId-edit.yaml
+++ b/doc/specs/tags/broadcasts/broadcast-round-broadcastRoundId-edit.yaml
@@ -36,7 +36,7 @@ post:
           schema:
             $ref: '../../schemas/Ok.yaml'
     "400":
-      description: The edition of the broadcast tournament failed.
+      description: The broadcast round update failed.
       content:
         application/json:
           schema:


### PR DESCRIPTION
`finished` is replaced with `status`, allowing broadcast owner to set the status to "started" if needed

https://github.com/lichess-org/lila/commit/af04531cf3c3fff50fc9e1060f4fa901387e8754