### PR TITLE
Games endpoint

### DIFF
--- a/doc/specs/examples/games-apiGamesUserJson.json
+++ b/doc/specs/examples/games-apiGamesUserJson.json
@@ -1,0 +1,465 @@
+{
+  "id": "Lr0wZGIA",
+  "rated": true,
+  "variant": "standard",
+  "speed": "blitz",
+  "perf": "blitz",
+  "createdAt": 1744231822635,
+  "lastMoveAt": 1744232244456,
+  "status": "resign",
+  "source": "arena",
+  "players": {
+    "white": {
+      "user": {
+        "name": "Lance5500",
+        "title": "LM",
+        "patron": true,
+        "id": "lance5500"
+      },
+      "rating": 2620,
+      "ratingDiff": -8,
+      "analysis": {
+        "inaccuracy": 3,
+        "mistake": 1,
+        "blunder": 3,
+        "acpl": 36,
+        "accuracy": 85
+      }
+    },
+    "black": {
+      "user": {
+        "name": "celvic",
+        "id": "celvic"
+      },
+      "rating": 2453,
+      "ratingDiff": 8,
+      "analysis": {
+        "inaccuracy": 4,
+        "mistake": 2,
+        "blunder": 0,
+        "acpl": 25,
+        "accuracy": 91
+      }
+    }
+  },
+  "winner": "black",
+  "opening": {
+    "eco": "A52",
+    "name": "Indian Defense: Budapest Defense",
+    "ply": 6
+  },
+  "moves": "d4 Nf6 c4 e5 dxe5 Ng4 Nh3 Nxe5 e3 g6 Nf4 Bg7 Be2 O-O O-O d6 Nc3 Nbd7 Qd2 a5 b3 a4 Rb1 Nc5 b4 Ne6 Nh3 c6 Bb2 a3 Ba1 Qh4 f4 Ng4 Bxg4 Qxg4 Ne4 Qh4 Bxg7 Nxg7 Nhf2 Rd8 Nxd6 Qe7 c5 Ne8 Rfd1 Be6 e4 b6 e5 Bd5 Rbc1 bxc5 bxc5 Rab8 Rc2 Nc7 h3 Ne6 Kh2 Qh4 g3 Qe7 Qe3 Rb2 Rdd2 Rdb8 Nd1 Rb1 Rxd5 cxd5 Nc3 d4 Nd5 Qxd6 cxd6 dxe3 Nxe3 R1b2",
+  "clocks": [
+    15003,
+    30003,
+    14931,
+    29931,
+    14835,
+    29867,
+    14763,
+    29571,
+    14699,
+    29491,
+    14555,
+    29371,
+    14491,
+    29091,
+    14419,
+    29035,
+    14283,
+    28963,
+    14195,
+    28795,
+    14115,
+    28731,
+    13915,
+    27451,
+    13227,
+    27267,
+    11675,
+    23379,
+    11067,
+    23179,
+    10947,
+    19155,
+    9515,
+    18963,
+    9387,
+    18963,
+    8515,
+    15227,
+    7851,
+    14843,
+    7363,
+    14355,
+    6179,
+    12323,
+    6083,
+    10155,
+    5811,
+    9435,
+    5667,
+    8875,
+    5339,
+    8283,
+    4747,
+    8051,
+    4651,
+    7627,
+    4547,
+    7435,
+    4307,
+    6995,
+    4147,
+    6627,
+    4051,
+    6035,
+    3987,
+    5691,
+    3931,
+    3211,
+    3763,
+    3083,
+    3043,
+    2859,
+    2731,
+    2739,
+    2627,
+    2267,
+    2275,
+    2131,
+    1747,
+    2048,
+    1445
+  ],
+  "analysis": [
+    {
+      "eval": 17
+    },
+    {
+      "eval": 19
+    },
+    {
+      "eval": 18
+    },
+    {
+      "eval": 51
+    },
+    {
+      "eval": 61
+    },
+    {
+      "eval": 58
+    },
+    {
+      "eval": 14
+    },
+    {
+      "eval": 21
+    },
+    {
+      "eval": 33
+    },
+    {
+      "eval": 51
+    },
+    {
+      "eval": 23
+    },
+    {
+      "eval": 30
+    },
+    {
+      "eval": 35
+    },
+    {
+      "eval": 37
+    },
+    {
+      "eval": 31
+    },
+    {
+      "eval": 25
+    },
+    {
+      "eval": 31
+    },
+    {
+      "eval": 30
+    },
+    {
+      "eval": 19
+    },
+    {
+      "eval": 25
+    },
+    {
+      "eval": 28
+    },
+    {
+      "eval": 32
+    },
+    {
+      "eval": 20
+    },
+    {
+      "eval": 58
+    },
+    {
+      "eval": 59
+    },
+    {
+      "eval": 69
+    },
+    {
+      "eval": 63
+    },
+    {
+      "eval": 66
+    },
+    {
+      "eval": 27
+    },
+    {
+      "eval": 32
+    },
+    {
+      "eval": 43
+    },
+    {
+      "eval": 110,
+      "best": "e6c7",
+      "variation": "Nc7 f4",
+      "judgment": {
+        "name": "Inaccuracy",
+        "comment": "Inaccuracy. Nc7 was best."
+      }
+    },
+    {
+      "eval": 109
+    },
+    {
+      "eval": 200,
+      "best": "e5d7",
+      "variation": "Nd7",
+      "judgment": {
+        "name": "Inaccuracy",
+        "comment": "Inaccuracy. Nd7 was best."
+      }
+    },
+    {
+      "eval": 200
+    },
+    {
+      "eval": 176
+    },
+    {
+      "eval": 213
+    },
+    {
+      "eval": 171
+    },
+    {
+      "eval": 88,
+      "best": "e4d6",
+      "variation": "Nxd6 Bxa1 Rxa1 Qf6 Rfd1 Ng7 Nf2 Qb2 c5 Be6 Nd3 Qxd2",
+      "judgment": {
+        "name": "Inaccuracy",
+        "comment": "Inaccuracy. Nxd6 was best."
+      }
+    },
+    {
+      "eval": 89
+    },
+    {
+      "eval": 52
+    },
+    {
+      "eval": 181,
+      "best": "d6d5",
+      "variation": "d5 cxd5 cxd5 Qxd5 Qe7 Qc5 Qxc5 bxc5 f5 Nc3 Ra5 Rb5",
+      "judgment": {
+        "name": "Mistake",
+        "comment": "Mistake. d5 was best."
+      }
+    },
+    {
+      "eval": 174
+    },
+    {
+      "eval": 178
+    },
+    {
+      "eval": 189
+    },
+    {
+      "eval": 160
+    },
+    {
+      "eval": 156
+    },
+    {
+      "eval": 161
+    },
+    {
+      "eval": 163
+    },
+    {
+      "eval": 139
+    },
+    {
+      "eval": 179
+    },
+    {
+      "eval": 224
+    },
+    {
+      "eval": 141,
+      "best": "f2g4",
+      "variation": "Ng4 bxc5 bxc5 Qa7 Qf2 h5 Rb7 Qa4 Rd4 Qa6 Nh6+ Kf8",
+      "judgment": {
+        "name": "Inaccuracy",
+        "comment": "Inaccuracy. Ng4 was best."
+      }
+    },
+    {
+      "eval": 124
+    },
+    {
+      "eval": 147
+    },
+    {
+      "eval": 154
+    },
+    {
+      "eval": 157
+    },
+    {
+      "eval": 311,
+      "best": "e7h4",
+      "variation": "Qh4 h3 Qg3 Nh1 Qh4 Rf1 Ng7 Qc3 Rb2 Rxb2 axb2 Qxb2",
+      "judgment": {
+        "name": "Mistake",
+        "comment": "Mistake. Qh4 was best."
+      }
+    },
+    {
+      "eval": 221,
+      "best": "f2g4",
+      "variation": "Ng4 Ne8 Nxe8 Bxa2 Ngf6+ Kh8 Nd6 Bb3 h3 Qe6 Rc3 Bxd1",
+      "judgment": {
+        "name": "Inaccuracy",
+        "comment": "Inaccuracy. Ng4 was best."
+      }
+    },
+    {
+      "eval": 359,
+      "best": "h7h5",
+      "variation": "h5 Nd3 f5 Kh2 Rd7 Rcc1 Qe6 Rc3 Nb5 Rc2 Nc7 Nb4",
+      "judgment": {
+        "name": "Inaccuracy",
+        "comment": "Inaccuracy. h5 was best."
+      }
+    },
+    {
+      "eval": 209,
+      "best": "f2g4",
+      "variation": "Ng4 Qh4 Nf6+ Kg7 Nxd5 cxd5 f5 Nf4 f6+ Kg8 c6 Rb2",
+      "judgment": {
+        "name": "Mistake",
+        "comment": "Mistake. Ng4 was best."
+      }
+    },
+    {
+      "eval": 267
+    },
+    {
+      "eval": 273
+    },
+    {
+      "eval": 220
+    },
+    {
+      "eval": 19,
+      "best": "f2g4",
+      "variation": "Ng4 Be4 Nf6+ Qxf6 exf6 Bxc2 Re1 Be4 Kg1 Bd5 f5 Rb2",
+      "judgment": {
+        "name": "Blunder",
+        "comment": "Blunder. Ng4 was best."
+      }
+    },
+    {
+      "eval": 27
+    },
+    {
+      "eval": 23
+    },
+    {
+      "eval": 32
+    },
+    {
+      "eval": -22
+    },
+    {
+      "eval": 34,
+      "best": "b2c2",
+      "variation": "Rxc2",
+      "judgment": {
+        "name": "Inaccuracy",
+        "comment": "Inaccuracy. Rxc2 was best."
+      }
+    },
+    {
+      "eval": -172,
+      "best": "d1f2",
+      "variation": "Nf2 R8b2",
+      "judgment": {
+        "name": "Blunder",
+        "comment": "Blunder. Nf2 was best."
+      }
+    },
+    {
+      "eval": -157
+    },
+    {
+      "eval": -450,
+      "best": "e3d2",
+      "variation": "Qd2 Qa7",
+      "judgment": {
+        "name": "Blunder",
+        "comment": "Blunder. Qd2 was best."
+      }
+    },
+    {
+      "eval": -508
+    },
+    {
+      "eval": -458
+    },
+    {
+      "eval": -443
+    },
+    {
+      "eval": -501
+    },
+    {
+      "eval": -468
+    },
+    {
+      "eval": -509
+    },
+    {
+      "eval": -476
+    }
+  ],
+  "tournament": "kwfVwY5B",
+  "clock": {
+    "initial": 300,
+    "increment": 0,
+    "totalTime": 300
+  },
+  "division": {
+    "middle": 25,
+    "end": 77
+  }
+}

--- a/doc/specs/examples/games-apiUserCurrentGameJson.json
+++ b/doc/specs/examples/games-apiUserCurrentGameJson.json
@@ -1,0 +1,465 @@
+{
+  "id": "Lr0wZGIA",
+  "rated": true,
+  "variant": "standard",
+  "speed": "blitz",
+  "perf": "blitz",
+  "createdAt": 1744231822635,
+  "lastMoveAt": 1744232244456,
+  "status": "resign",
+  "source": "arena",
+  "players": {
+    "white": {
+      "user": {
+        "name": "Lance5500",
+        "title": "LM",
+        "patron": true,
+        "id": "lance5500"
+      },
+      "rating": 2620,
+      "ratingDiff": -8,
+      "analysis": {
+        "inaccuracy": 3,
+        "mistake": 1,
+        "blunder": 3,
+        "acpl": 36,
+        "accuracy": 85
+      }
+    },
+    "black": {
+      "user": {
+        "name": "celvic",
+        "id": "celvic"
+      },
+      "rating": 2453,
+      "ratingDiff": 8,
+      "analysis": {
+        "inaccuracy": 4,
+        "mistake": 2,
+        "blunder": 0,
+        "acpl": 25,
+        "accuracy": 91
+      }
+    }
+  },
+  "winner": "black",
+  "opening": {
+    "eco": "A52",
+    "name": "Indian Defense: Budapest Defense",
+    "ply": 6
+  },
+  "moves": "d4 Nf6 c4 e5 dxe5 Ng4 Nh3 Nxe5 e3 g6 Nf4 Bg7 Be2 O-O O-O d6 Nc3 Nbd7 Qd2 a5 b3 a4 Rb1 Nc5 b4 Ne6 Nh3 c6 Bb2 a3 Ba1 Qh4 f4 Ng4 Bxg4 Qxg4 Ne4 Qh4 Bxg7 Nxg7 Nhf2 Rd8 Nxd6 Qe7 c5 Ne8 Rfd1 Be6 e4 b6 e5 Bd5 Rbc1 bxc5 bxc5 Rab8 Rc2 Nc7 h3 Ne6 Kh2 Qh4 g3 Qe7 Qe3 Rb2 Rdd2 Rdb8 Nd1 Rb1 Rxd5 cxd5 Nc3 d4 Nd5 Qxd6 cxd6 dxe3 Nxe3 R1b2",
+  "clocks": [
+    15003,
+    30003,
+    14931,
+    29931,
+    14835,
+    29867,
+    14763,
+    29571,
+    14699,
+    29491,
+    14555,
+    29371,
+    14491,
+    29091,
+    14419,
+    29035,
+    14283,
+    28963,
+    14195,
+    28795,
+    14115,
+    28731,
+    13915,
+    27451,
+    13227,
+    27267,
+    11675,
+    23379,
+    11067,
+    23179,
+    10947,
+    19155,
+    9515,
+    18963,
+    9387,
+    18963,
+    8515,
+    15227,
+    7851,
+    14843,
+    7363,
+    14355,
+    6179,
+    12323,
+    6083,
+    10155,
+    5811,
+    9435,
+    5667,
+    8875,
+    5339,
+    8283,
+    4747,
+    8051,
+    4651,
+    7627,
+    4547,
+    7435,
+    4307,
+    6995,
+    4147,
+    6627,
+    4051,
+    6035,
+    3987,
+    5691,
+    3931,
+    3211,
+    3763,
+    3083,
+    3043,
+    2859,
+    2731,
+    2739,
+    2627,
+    2267,
+    2275,
+    2131,
+    1747,
+    2048,
+    1445
+  ],
+  "analysis": [
+    {
+      "eval": 17
+    },
+    {
+      "eval": 19
+    },
+    {
+      "eval": 18
+    },
+    {
+      "eval": 51
+    },
+    {
+      "eval": 61
+    },
+    {
+      "eval": 58
+    },
+    {
+      "eval": 14
+    },
+    {
+      "eval": 21
+    },
+    {
+      "eval": 33
+    },
+    {
+      "eval": 51
+    },
+    {
+      "eval": 23
+    },
+    {
+      "eval": 30
+    },
+    {
+      "eval": 35
+    },
+    {
+      "eval": 37
+    },
+    {
+      "eval": 31
+    },
+    {
+      "eval": 25
+    },
+    {
+      "eval": 31
+    },
+    {
+      "eval": 30
+    },
+    {
+      "eval": 19
+    },
+    {
+      "eval": 25
+    },
+    {
+      "eval": 28
+    },
+    {
+      "eval": 32
+    },
+    {
+      "eval": 20
+    },
+    {
+      "eval": 58
+    },
+    {
+      "eval": 59
+    },
+    {
+      "eval": 69
+    },
+    {
+      "eval": 63
+    },
+    {
+      "eval": 66
+    },
+    {
+      "eval": 27
+    },
+    {
+      "eval": 32
+    },
+    {
+      "eval": 43
+    },
+    {
+      "eval": 110,
+      "best": "e6c7",
+      "variation": "Nc7 f4",
+      "judgment": {
+        "name": "Inaccuracy",
+        "comment": "Inaccuracy. Nc7 was best."
+      }
+    },
+    {
+      "eval": 109
+    },
+    {
+      "eval": 200,
+      "best": "e5d7",
+      "variation": "Nd7",
+      "judgment": {
+        "name": "Inaccuracy",
+        "comment": "Inaccuracy. Nd7 was best."
+      }
+    },
+    {
+      "eval": 200
+    },
+    {
+      "eval": 176
+    },
+    {
+      "eval": 213
+    },
+    {
+      "eval": 171
+    },
+    {
+      "eval": 88,
+      "best": "e4d6",
+      "variation": "Nxd6 Bxa1 Rxa1 Qf6 Rfd1 Ng7 Nf2 Qb2 c5 Be6 Nd3 Qxd2",
+      "judgment": {
+        "name": "Inaccuracy",
+        "comment": "Inaccuracy. Nxd6 was best."
+      }
+    },
+    {
+      "eval": 89
+    },
+    {
+      "eval": 52
+    },
+    {
+      "eval": 181,
+      "best": "d6d5",
+      "variation": "d5 cxd5 cxd5 Qxd5 Qe7 Qc5 Qxc5 bxc5 f5 Nc3 Ra5 Rb5",
+      "judgment": {
+        "name": "Mistake",
+        "comment": "Mistake. d5 was best."
+      }
+    },
+    {
+      "eval": 174
+    },
+    {
+      "eval": 178
+    },
+    {
+      "eval": 189
+    },
+    {
+      "eval": 160
+    },
+    {
+      "eval": 156
+    },
+    {
+      "eval": 161
+    },
+    {
+      "eval": 163
+    },
+    {
+      "eval": 139
+    },
+    {
+      "eval": 179
+    },
+    {
+      "eval": 224
+    },
+    {
+      "eval": 141,
+      "best": "f2g4",
+      "variation": "Ng4 bxc5 bxc5 Qa7 Qf2 h5 Rb7 Qa4 Rd4 Qa6 Nh6+ Kf8",
+      "judgment": {
+        "name": "Inaccuracy",
+        "comment": "Inaccuracy. Ng4 was best."
+      }
+    },
+    {
+      "eval": 124
+    },
+    {
+      "eval": 147
+    },
+    {
+      "eval": 154
+    },
+    {
+      "eval": 157
+    },
+    {
+      "eval": 311,
+      "best": "e7h4",
+      "variation": "Qh4 h3 Qg3 Nh1 Qh4 Rf1 Ng7 Qc3 Rb2 Rxb2 axb2 Qxb2",
+      "judgment": {
+        "name": "Mistake",
+        "comment": "Mistake. Qh4 was best."
+      }
+    },
+    {
+      "eval": 221,
+      "best": "f2g4",
+      "variation": "Ng4 Ne8 Nxe8 Bxa2 Ngf6+ Kh8 Nd6 Bb3 h3 Qe6 Rc3 Bxd1",
+      "judgment": {
+        "name": "Inaccuracy",
+        "comment": "Inaccuracy. Ng4 was best."
+      }
+    },
+    {
+      "eval": 359,
+      "best": "h7h5",
+      "variation": "h5 Nd3 f5 Kh2 Rd7 Rcc1 Qe6 Rc3 Nb5 Rc2 Nc7 Nb4",
+      "judgment": {
+        "name": "Inaccuracy",
+        "comment": "Inaccuracy. h5 was best."
+      }
+    },
+    {
+      "eval": 209,
+      "best": "f2g4",
+      "variation": "Ng4 Qh4 Nf6+ Kg7 Nxd5 cxd5 f5 Nf4 f6+ Kg8 c6 Rb2",
+      "judgment": {
+        "name": "Mistake",
+        "comment": "Mistake. Ng4 was best."
+      }
+    },
+    {
+      "eval": 267
+    },
+    {
+      "eval": 273
+    },
+    {
+      "eval": 220
+    },
+    {
+      "eval": 19,
+      "best": "f2g4",
+      "variation": "Ng4 Be4 Nf6+ Qxf6 exf6 Bxc2 Re1 Be4 Kg1 Bd5 f5 Rb2",
+      "judgment": {
+        "name": "Blunder",
+        "comment": "Blunder. Ng4 was best."
+      }
+    },
+    {
+      "eval": 27
+    },
+    {
+      "eval": 23
+    },
+    {
+      "eval": 32
+    },
+    {
+      "eval": -22
+    },
+    {
+      "eval": 34,
+      "best": "b2c2",
+      "variation": "Rxc2",
+      "judgment": {
+        "name": "Inaccuracy",
+        "comment": "Inaccuracy. Rxc2 was best."
+      }
+    },
+    {
+      "eval": -172,
+      "best": "d1f2",
+      "variation": "Nf2 R8b2",
+      "judgment": {
+        "name": "Blunder",
+        "comment": "Blunder. Nf2 was best."
+      }
+    },
+    {
+      "eval": -157
+    },
+    {
+      "eval": -450,
+      "best": "e3d2",
+      "variation": "Qd2 Qa7",
+      "judgment": {
+        "name": "Blunder",
+        "comment": "Blunder. Qd2 was best."
+      }
+    },
+    {
+      "eval": -508
+    },
+    {
+      "eval": -458
+    },
+    {
+      "eval": -443
+    },
+    {
+      "eval": -501
+    },
+    {
+      "eval": -468
+    },
+    {
+      "eval": -509
+    },
+    {
+      "eval": -476
+    }
+  ],
+  "tournament": "kwfVwY5B",
+  "clock": {
+    "initial": 300,
+    "increment": 0,
+    "totalTime": 300
+  },
+  "division": {
+    "middle": 25,
+    "end": 77
+  }
+}

--- a/doc/specs/examples/games-gamesExportIds.json
+++ b/doc/specs/examples/games-gamesExportIds.json
@@ -1,0 +1,90 @@
+{
+  "id": "TJxUmbWK",
+  "rated": true,
+  "variant": "standard",
+  "speed": "rapid",
+  "perf": "rapid",
+  "createdAt": 1504125627542,
+  "lastMoveAt": 1504126012148,
+  "status": "resign",
+  "source": "arena",
+  "players": {
+    "white": {
+      "user": {
+        "name": "arex",
+        "patron": true,
+        "id": "arex"
+      },
+      "rating": 1627,
+      "ratingDiff": 15
+    },
+    "black": {
+      "user": {
+        "name": "JERC-12Jesus",
+        "id": "jerc-12jesus"
+      },
+      "rating": 1740,
+      "ratingDiff": -15
+    }
+  },
+  "winner": "white",
+  "opening": {
+    "eco": "B07",
+    "name": "Pirc Defense",
+    "ply": 6
+  },
+  "moves": "e4 d6 d4 Nf6 Nc3 g6 Bd3 Bg7 Be3 O-O Qd2 Ng4 O-O-O Nxe3 Qxe3 Nd7 f4 Nf6 h3 c6 g4 Qb6 Nf3 c5 dxc5 Qxc5 Qxc5 dxc5 e5 Nd7 Nd5 e6 Ne7+ Kh8 Bb5 a6 Bxd7 Bxd7 Rxd7 Rfe8 Rxb7",
+  "clocks": [
+    60003,
+    60003,
+    59755,
+    59795,
+    59531,
+    59563,
+    59155,
+    59243,
+    58635,
+    59003,
+    58355,
+    57987,
+    56811,
+    57787,
+    56667,
+    57099,
+    56499,
+    56227,
+    56019,
+    54827,
+    55419,
+    53507,
+    54387,
+    51467,
+    49931,
+    50203,
+    48579,
+    50203,
+    48443,
+    47363,
+    47539,
+    46059,
+    43251,
+    45691,
+    40491,
+    44107,
+    39579,
+    44107,
+    39451,
+    43811,
+    39313,
+    43129
+  ],
+  "tournament": "Xg7M4och",
+  "clock": {
+    "initial": 600,
+    "increment": 0,
+    "totalTime": 600
+  },
+  "division": {
+    "middle": 22
+  }
+}

--- a/doc/specs/examples/games-getOneGameJson.json
+++ b/doc/specs/examples/games-getOneGameJson.json
@@ -1,0 +1,662 @@
+{
+  "id": "q7ZvsdUF",
+  "rated": true,
+  "variant": "standard",
+  "speed": "blitz",
+  "perf": "blitz",
+  "createdAt": 1514505150384,
+  "lastMoveAt": 1514505592843,
+  "status": "draw",
+  "source": "arena",
+  "players": {
+    "white": {
+      "user": {
+        "name": "Lance5500",
+        "title": "LM",
+        "patron": true,
+        "id": "lance5500"
+      },
+      "rating": 2389,
+      "ratingDiff": 4,
+      "analysis": {
+        "inaccuracy": 5,
+        "mistake": 2,
+        "blunder": 1,
+        "acpl": 26,
+        "accuracy": 90
+      }
+    },
+    "black": {
+      "user": {
+        "name": "TryingHard87",
+        "id": "tryinghard87"
+      },
+      "rating": 2498,
+      "ratingDiff": -4,
+      "analysis": {
+        "inaccuracy": 3,
+        "mistake": 3,
+        "blunder": 1,
+        "acpl": 26,
+        "accuracy": 90
+      }
+    }
+  },
+  "opening": {
+    "eco": "D31",
+    "name": "Semi-Slav Defense: Marshall Gambit",
+    "ply": 7
+  },
+  "moves": "d4 d5 c4 c6 Nc3 e6 e4 Nd7 exd5 cxd5 cxd5 exd5 Nxd5 Nb6 Bb5+ Bd7 Qe2+ Ne7 Nxb6 Qxb6 Bxd7+ Kxd7 Nf3 Qa6 Ne5+ Ke8 Qf3 f6 Nd3 Qc6 Qe2 Kf7 O-O Kg8 Bd2 Re8 Rac1 Nf5 Be3 Qe6 Rfe1 g6 b3 Bd6 Qd2 Kf7 Bf4 Qd7 Bxd6 Nxd6 Nc5 Rxe1+ Rxe1 Qc6 f3 Re8 Rxe8 Nxe8 Kf2 Nc7 Qb4 b6 Qc4+ Nd5 Nd3 Qe6 Nb4 Ne7 Qxe6+ Kxe6 Ke3 Kd6 g3 h6 Kd3 h5 Nc2 Kd5 a3 Nc6 Ne3+ Kd6 h4 Nd8 g4 Ne6 Ke4 Ng7 Nc4+ Ke6 d5+ Kd7 a4 g5 gxh5 Nxh5 hxg5 fxg5 Kf5 Nf4 Ne3 Nh3 Kg4 Ng1 Nc4 Kc7 Nd2 Kd6 Kxg5 Kxd5 f4 Nh3+ Kg4 Nf2+ Kf3 Nd3 Ke3 Nc5 Kf3 Ke6 Ke3 Kf5 Kd4 Ne6+ Kc4",
+  "clocks": [
+    15003,
+    30003,
+    14947,
+    30299,
+    14891,
+    30555,
+    14811,
+    30803,
+    14723,
+    30939,
+    14723,
+    31187,
+    14723,
+    31067,
+    14467,
+    31219,
+    14403,
+    31323,
+    13811,
+    30771,
+    13715,
+    30883,
+    13715,
+    30747,
+    13531,
+    30643,
+    13387,
+    30619,
+    13203,
+    30771,
+    12971,
+    30739,
+    12867,
+    30619,
+    12427,
+    30699,
+    12267,
+    30515,
+    11291,
+    30323,
+    10339,
+    30195,
+    9675,
+    30003,
+    9155,
+    29579,
+    8667,
+    29091,
+    8379,
+    29139,
+    8259,
+    29059,
+    8107,
+    28883,
+    7731,
+    29043,
+    7587,
+    28915,
+    7283,
+    29083,
+    6827,
+    28979,
+    6747,
+    28875,
+    6483,
+    29051,
+    5875,
+    29027,
+    5507,
+    29227,
+    5459,
+    26931,
+    5235,
+    26587,
+    5123,
+    26427,
+    5123,
+    25603,
+    5123,
+    24995,
+    5019,
+    25179,
+    4875,
+    25027,
+    4787,
+    24411,
+    4235,
+    24203,
+    3835,
+    24059,
+    3763,
+    23963,
+    3763,
+    22979,
+    3403,
+    22939,
+    3331,
+    23067,
+    3283,
+    22947,
+    3195,
+    20643,
+    3083,
+    20643,
+    3043,
+    20195,
+    2795,
+    19995,
+    2707,
+    20243,
+    2651,
+    19411,
+    2531,
+    18203,
+    2443,
+    18379,
+    2379,
+    18571,
+    2059,
+    18451,
+    1835,
+    18587,
+    1675,
+    18763,
+    1556,
+    18226
+  ],
+  "analysis": [
+    {
+      "eval": 8
+    },
+    {
+      "eval": 7
+    },
+    {
+      "eval": 10
+    },
+    {
+      "eval": 14
+    },
+    {
+      "eval": 2
+    },
+    {
+      "eval": 9
+    },
+    {
+      "eval": 5
+    },
+    {
+      "eval": 85,
+      "best": "d5e4",
+      "variation": "dxe4 Nxe4 Bb4+ Nc3 c5 a3 Bxc3+ bxc3 Nc6 Nf3",
+      "judgment": {
+        "name": "Inaccuracy",
+        "comment": "Inaccuracy. dxe4 was best."
+      }
+    },
+    {
+      "eval": 96
+    },
+    {
+      "eval": 98
+    },
+    {
+      "eval": 88
+    },
+    {
+      "eval": 87
+    },
+    {
+      "eval": 81
+    },
+    {
+      "eval": 88
+    },
+    {
+      "eval": 82
+    },
+    {
+      "eval": 90
+    },
+    {
+      "eval": 79
+    },
+    {
+      "eval": 160,
+      "best": "f8e7",
+      "variation": "Be7 Nxb6 axb6 Nf3 Nf6 O-O O-O Bd2 Bd6 Bc4 Re8 Qd3 Be6 Bxe6",
+      "judgment": {
+        "name": "Inaccuracy",
+        "comment": "Inaccuracy. Be7 was best."
+      }
+    },
+    {
+      "eval": 146
+    },
+    {
+      "eval": 151
+    },
+    {
+      "eval": 149
+    },
+    {
+      "eval": 160
+    },
+    {
+      "eval": 151
+    },
+    {
+      "eval": 150
+    },
+    {
+      "eval": 164
+    },
+    {
+      "eval": 190
+    },
+    {
+      "eval": 44,
+      "best": "e5d3",
+      "variation": "Nd3 Rd8",
+      "judgment": {
+        "name": "Mistake",
+        "comment": "Mistake. Nd3 was best."
+      }
+    },
+    {
+      "eval": 61
+    },
+    {
+      "eval": 59
+    },
+    {
+      "eval": 54
+    },
+    {
+      "eval": -34,
+      "best": "e1e2",
+      "variation": "Ke2 Rd8 Rd1 Qxf3+ Kxf3 Nf5 Be3 Nh4+ Kg3 g5 f4 gxf4+ Bxf4 Nf5+",
+      "judgment": {
+        "name": "Inaccuracy",
+        "comment": "Inaccuracy. Ke2 was best."
+      }
+    },
+    {
+      "eval": 158,
+      "best": "c6g2",
+      "variation": "Qxg2 Rf1 Qd5 Be3 Rc8 Nf4 Qf5 Rc1 Rxc1+ Bxc1 g5 Ne6 Kf7 Nd8+",
+      "judgment": {
+        "name": "Blunder",
+        "comment": "Blunder. Qxg2 was best."
+      }
+    },
+    {
+      "eval": 142
+    },
+    {
+      "eval": 183
+    },
+    {
+      "eval": 177
+    },
+    {
+      "eval": 340,
+      "best": "e7d5",
+      "variation": "Nd5 Rac1 Qe8 Qf3 Rd8 Nf4 Qf7 Nxd5 Qxd5 Qxd5+ Rxd5 Rc7 Rxd4 Bc3",
+      "judgment": {
+        "name": "Mistake",
+        "comment": "Mistake. Nd5 was best."
+      }
+    },
+    {
+      "eval": 169,
+      "best": "f1e1",
+      "variation": "Rfe1 Rc8 Rac1 Qd7 Nf4 Rxc1 Rxc1 h5 Qd3 a5 Qb3+ Kh7 Rc5 Nf5",
+      "judgment": {
+        "name": "Mistake",
+        "comment": "Mistake. Rfe1 was best."
+      }
+    },
+    {
+      "eval": 200
+    },
+    {
+      "eval": 120,
+      "best": "e2h5",
+      "variation": "Qh5 Qd7 Rc7 Qxc7 Qxe8 Qc6 Qd8 h6 Bb4 Qe4 Ne1 Kf7 Nf3 Qc6",
+      "judgment": {
+        "name": "Inaccuracy",
+        "comment": "Inaccuracy. Qh5 was best."
+      }
+    },
+    {
+      "eval": 167
+    },
+    {
+      "eval": 147
+    },
+    {
+      "eval": 200,
+      "best": "e6d7",
+      "variation": "Qd7 Nf4"
+    },
+    {
+      "eval": 92,
+      "best": "c1c7",
+      "variation": "Rc7 Qxa2",
+      "judgment": {
+        "name": "Inaccuracy",
+        "comment": "Inaccuracy. Rc7 was best."
+      }
+    },
+    {
+      "eval": 102
+    },
+    {
+      "eval": 95
+    },
+    {
+      "eval": 95
+    },
+    {
+      "eval": 61
+    },
+    {
+      "eval": 79
+    },
+    {
+      "eval": 72
+    },
+    {
+      "eval": 201,
+      "best": "d7d6",
+      "variation": "Qxd6 d5 Rxe1+ Rxe1 Re8 Rxe8 Kxe8 Nf4 Qe5 g3 Nd4 Qc3 Kd7 Qb4",
+      "judgment": {
+        "name": "Mistake",
+        "comment": "Mistake. Qxd6 was best."
+      }
+    },
+    {
+      "eval": 190
+    },
+    {
+      "eval": 183
+    },
+    {
+      "eval": 106,
+      "best": "d2e1",
+      "variation": "Qxe1 Qe7 Qxe7+ Kxe7 Nxb7 Rc8 Re1+ Kd7 Nc5+ Kc6 g3 Re8 Rc1 Kd5",
+      "judgment": {
+        "name": "Inaccuracy",
+        "comment": "Inaccuracy. Qxe1 was best."
+      }
+    },
+    {
+      "eval": 108
+    },
+    {
+      "eval": 93
+    },
+    {
+      "eval": 101
+    },
+    {
+      "eval": 101
+    },
+    {
+      "eval": 107
+    },
+    {
+      "eval": 100
+    },
+    {
+      "eval": 105
+    },
+    {
+      "eval": 103
+    },
+    {
+      "eval": 118
+    },
+    {
+      "eval": 117
+    },
+    {
+      "eval": 116
+    },
+    {
+      "eval": 83
+    },
+    {
+      "eval": 95
+    },
+    {
+      "eval": 90
+    },
+    {
+      "eval": 94
+    },
+    {
+      "eval": 94
+    },
+    {
+      "eval": 93
+    },
+    {
+      "eval": 88
+    },
+    {
+      "eval": 102
+    },
+    {
+      "eval": 79
+    },
+    {
+      "eval": 120
+    },
+    {
+      "eval": 114
+    },
+    {
+      "eval": 124
+    },
+    {
+      "eval": 108
+    },
+    {
+      "eval": 133
+    },
+    {
+      "eval": 100
+    },
+    {
+      "eval": 156,
+      "best": "d5d6",
+      "variation": "Kd6 Kc4"
+    },
+    {
+      "eval": 198
+    },
+    {
+      "eval": 179
+    },
+    {
+      "eval": 167
+    },
+    {
+      "eval": 227,
+      "best": "c6a5",
+      "variation": "Na5 b4"
+    },
+    {
+      "eval": 225
+    },
+    {
+      "eval": 209
+    },
+    {
+      "eval": 207
+    },
+    {
+      "eval": 192
+    },
+    {
+      "eval": 173
+    },
+    {
+      "eval": 243,
+      "best": "d6c6",
+      "variation": "Kc6 a4 a6 Ne3 Kd6 d5 Kd7 Kd4 Ne8 gxh5 gxh5 Nf5 Nd6 Ng3",
+      "judgment": {
+        "name": "Inaccuracy",
+        "comment": "Inaccuracy. Kc6 was best."
+      }
+    },
+    {
+      "eval": 219
+    },
+    {
+      "eval": 234
+    },
+    {
+      "eval": 201
+    },
+    {
+      "eval": 342,
+      "best": "d7e7",
+      "variation": "Ke7 Kf4 Ne8 g5 Kf7 gxf6 Kxf6 Nd2 Ng7 Ne4+ Ke7 Kg5 Nf5 d6+",
+      "judgment": {
+        "name": "Mistake",
+        "comment": "Mistake. Ke7 was best."
+      }
+    },
+    {
+      "eval": 318
+    },
+    {
+      "eval": 342
+    },
+    {
+      "eval": 307
+    },
+    {
+      "eval": 323
+    },
+    {
+      "eval": 270
+    },
+    {
+      "eval": 313
+    },
+    {
+      "eval": 279
+    },
+    {
+      "eval": 303
+    },
+    {
+      "eval": 286
+    },
+    {
+      "eval": 277
+    },
+    {
+      "eval": 215
+    },
+    {
+      "eval": 213
+    },
+    {
+      "eval": 8,
+      "best": "b3b4",
+      "variation": "b4 Kc8 Nd6+ Kd7 Ne4 a6 Nc3 Kd6 Kg3 Ke5 b5 axb5 axb5 Kd6",
+      "judgment": {
+        "name": "Blunder",
+        "comment": "Blunder. b4 was best."
+      }
+    },
+    {
+      "eval": 8
+    },
+    {
+      "eval": 8
+    },
+    {
+      "eval": 8
+    },
+    {
+      "eval": 21
+    },
+    {
+      "eval": 54
+    },
+    {
+      "eval": 42
+    },
+    {
+      "eval": 57
+    },
+    {
+      "eval": 25
+    },
+    {
+      "eval": 63
+    },
+    {
+      "eval": 8,
+      "best": "f3g4",
+      "variation": "Kg4 Nf2+ Kf5 Kd4 Nf3+ Kc3 Ke6 Kxb3 f5 Ne4 Ke5 Nf2 Kf4 Nd3+",
+      "judgment": {
+        "name": "Inaccuracy",
+        "comment": "Inaccuracy. Kg4 was best."
+      }
+    },
+    {
+      "eval": 8
+    },
+    {
+      "eval": 8
+    },
+    {
+      "eval": 8
+    },
+    {
+      "eval": 8
+    },
+    {
+      "eval": 8
+    },
+    {
+      "eval": 8
+    },
+    {
+      "eval": 8
+    },
+    {
+      "eval": 8
+    }
+  ],
+  "tournament": "winter17",
+  "clock": {
+    "initial": 300,
+    "increment": 3,
+    "totalTime": 420
+  },
+  "division": {
+    "middle": 22,
+    "end": 53
+  }
+}

--- a/doc/specs/schemas/GameJson.yaml
+++ b/doc/specs/schemas/GameJson.yaml
@@ -18,6 +18,8 @@ properties:
     format: int64
   status:
     $ref: "./GameStatus.yaml"
+  source:
+    type: string
   players:
     type: object
     properties:

--- a/doc/specs/tags/games/api-games-export-_ids.yaml
+++ b/doc/specs/tags/games/api-games-export-_ids.yaml
@@ -108,3 +108,5 @@ post:
         application/x-ndjson:
           schema:
             $ref: "../../schemas/GameJson.yaml"
+          example:
+            $ref: "../../examples/games-gamesExportIds.json"

--- a/doc/specs/tags/games/api-games-user-username.yaml
+++ b/doc/specs/tags/games/api-games-user-username.yaml
@@ -199,3 +199,5 @@ get:
         application/x-ndjson:
           schema:
             $ref: "../../schemas/GameJson.yaml"
+          example:
+            $ref: "../../examples/games-apiGamesUserJson.json"

--- a/doc/specs/tags/games/api-user-username-current-game.yaml
+++ b/doc/specs/tags/games/api-user-username-current-game.yaml
@@ -103,3 +103,5 @@ get:
         application/json:
           schema:
             $ref: "../../schemas/GameJson.yaml"
+          example:
+            $ref: "../../examples/games-apiUserCurrentGameJson.json"

--- a/doc/specs/tags/games/game-export-gameId.yaml
+++ b/doc/specs/tags/games/game-export-gameId.yaml
@@ -113,3 +113,5 @@ get:
         application/json:
           schema:
             $ref: "../../schemas/GameJson.yaml"
+          example:
+            $ref: "../../examples/games-getOneGameJson.json"

--- a/scripts/update-examples/games.ts
+++ b/scripts/update-examples/games.ts
@@ -1,0 +1,91 @@
+import { example, prodClient, readNdJson } from "./config";
+
+example(
+  "games",
+  "getOneGameJson",
+  await prodClient().GET("/game/export/{gameId}", {
+    params: {
+      path: {
+        gameId: "q7ZvsdUF",
+      },
+      query: {
+          accuracy: true,
+          literate: true,
+      },
+    },
+    headers: {
+      "Accept": "application/json",
+    },
+  }),
+);
+
+example(
+  "games",
+  "apiUserCurrentGameJson",
+  await prodClient().GET("/api/user/{username}/current-game", {
+    params: {
+      path: {
+        username: "lance5500",
+      },
+      query: {
+          accuracy: true,
+          division: true,
+          literate: true,
+      },
+    },
+    headers: {
+      "Accept": "application/json",
+    },
+  }),
+);
+
+await prodClient()
+  .GET("/api/games/user/{username}", {
+    params: {
+      path: {
+        username: "lance5500",
+      },
+      query: {
+        max: 1,
+        clocks: true,
+        evals: true,
+        accuracy: true,
+        opening: true,
+        division: true,
+        literate: true,
+      },
+    },
+    headers: {
+      "Accept": "application/x-ndjson",
+    },
+    parseAs: "stream",
+  })
+  .then((response) =>
+    readNdJson(response.response, (line: any) => {
+        example("games", "apiGamesUserJson", line);
+    }),
+  );
+
+example(
+  "games",
+  "gamesExportIds",
+  await prodClient().POST("/api/games/export/_ids", {
+    body: "TJxUmbWK",
+    params: {
+      query: {
+        clocks: true,
+        evals: true,
+        accuracy: true,
+        opening: true,
+        division: true,
+        literate: true,
+      },
+    },
+    headers: {
+      "Content-Type": "text/plain",
+      "Accept": "application/x-ndjson",
+    },
+    bodySerializer: (body) => body,
+  }),
+);
+


### PR DESCRIPTION
Add script for generating examples for game endpoints

Includes the first 4 game endpoints:
- Export one game
- Export ongoing game of a user
- Export games of a user
- Export games by IDs
