### PR TITLE
update max limit to 100 for both broadcast push and upstream ids

### DIFF
--- a/doc/specs/schemas/BroadcastRoundForm.yaml
+++ b/doc/specs/schemas/BroadcastRoundForm.yaml
@@ -118,7 +118,7 @@ allOf:
           syncIds:
             type: string
             description: |
-              Lichess game IDs - Up to 64 Lichess game IDs, separated by spaces.
+              Lichess game IDs - Up to 100 Lichess game IDs, separated by spaces.
       - type: object
         title: retrieve games via Lichess usernames
         required:

--- a/doc/specs/tags/broadcasts/broadcast-round-broadcastRoundId-push.yaml
+++ b/doc/specs/tags/broadcasts/broadcast-round-broadcastRoundId-push.yaml
@@ -18,7 +18,7 @@ post:
         minLength: 8
         maxLength: 8
   requestBody:
-    description: The PGN. It can contain up to 64 games, separated by a double new line.
+    description: The PGN. It can contain up to 100 games, separated by a double new line.
     required: true
     content:
       text/plain:


### PR DESCRIPTION
https://github.com/lichess-org/lila/blob/822a320c77f5d58abde1a0fbfea253c5789cecdf/modules/relay/src/main/RelayRoundForm.scala#L53

and 

https://github.com/lichess-org/lila/blob/822a320c77f5d58abde1a0fbfea253c5789cecdf/modules/relay/src/main/RelayPush.scala#L92

which is 100 https://github.com/lichess-org/lila/blob/822a320c77f5d58abde1a0fbfea253c5789cecdf/modules/relay/src/main/RelayFetch.scala#L374