### PR TITLE
Clarify URL-encoded tag pairs are supported in analysis pgn URL

### DIFF
--- a/doc/specs/tags/games/api-import.yaml
+++ b/doc/specs/tags/games/api-import.yaml
@@ -5,7 +5,7 @@ post:
     Import a game from PGN. See <https://lichess.org/paste>.
     Rate limiting: 200 games per hour for OAuth requests, 100 games per hour for anonymous requests.
     To broadcast ongoing games, consider [pushing to a broadcast instead](#operation/broadcastPush).
-    To analyse a position or a line, just construct an analysis board URL:
+    To analyse a position or a line, just construct an analysis board URL (most standard tags supported if URL-encoded):
     [https://lichess.org/analysis/pgn/e4_e5_Nf3_Nc6_Bc4_Bc5_Bxf7+](https://lichess.org/analysis/pgn/e4_e5_Nf3_Nc6_Bc4_Bc5_Bxf7+)
   tags:
     - Games


### PR DESCRIPTION
In a couple of issues/Reddit posts (e.g. https://github.com/lichess-org/lila/issues/10205#issuecomment-1220701218 and https://github.com/lichess-org/lila/issues/11401#issuecomment-1230638985), it seems people know that `/analysis/pgn/` can accept a move list but don't realise since it takes pgn, URL-encoded tag pairs are allowed.

e.g. https://lichess.org/analysis/pgn/%5BFEN%20%22r1bqkbnr/pppp1ppp/2n5/4p2Q/2B1P3/8/PPPP1PPP/RNB1K1NR%20b%20KQkq%20-%203%203%22%5DNf6_Qxf7

Perhaps a small addition in the API docs will help. I don't think an example URL with a custom FEN is needed there as it'll be quite long, but if appropriate, I can add one.