### PR TITLE
Remove git commit co-author from daily publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,7 @@ jobs:
         if: steps.check_changes.outputs.changed_files != ''
         with:
           commit_message: 'Update API version'
+          commit_author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
   publish-to-github-pages:
     if: github.repository == 'lichess-org/api'
     needs: publish-to-npm


### PR DESCRIPTION
set `commit_author` value to github-actions[bot] to match the default `commit_user_email`