### PR TITLE
uci outputs use chess960 notation

### DIFF
--- a/doc/specs/schemas/CloudEval.yaml
+++ b/doc/specs/schemas/CloudEval.yaml
@@ -27,7 +27,9 @@ properties:
               description: Evaluation in centi-pawns, from White's point of view
             moves:
               type: string
-              description: Variation in UCI notation
+              description: |
+                Variation in UCI notation (King to rook for Chess960-compatible
+                castling notation)
         - type: object
           title: Mate variation
           required:
@@ -39,7 +41,9 @@ properties:
               description: Evaluation in moves to mate, from White's point of view
             moves:
               type: string
-              description: Variation in UCI notation
+              description: |
+                Variation in UCI notation (King to rook for Chess960-compatible
+                castling notation)
 
 example:
   {

--- a/doc/specs/schemas/GameStateEvent.yaml
+++ b/doc/specs/schemas/GameStateEvent.yaml
@@ -5,7 +5,9 @@ properties:
     const: gameState
   moves:
     type: string
-    description: Current moves in UCI format
+    description: |
+      Current moves in UCI format (King to rook for Chess690-compatible castling
+      notation)
   wtime:
     type: integer
     description: Integer of milliseconds White has left on the clock

--- a/doc/specs/schemas/TvFeed.yaml
+++ b/doc/specs/schemas/TvFeed.yaml
@@ -65,7 +65,9 @@ properties:
             description: The FEN of the current position
           lm:
             type: string
-            description: The last move in UCI format
+            description: |
+              The last move in UCI format (King to rook for Chess960-compatible
+              castling notation)
           wc:
             type: integer
             description: White's clock in seconds


### PR DESCRIPTION
following-up on https://github.com/lichess-org/lila/issues/18230