### PR TITLE
fix: mention OAuth token can read private study by Id and chapter data

### DIFF
--- a/doc/specs/tags/studies/api-study-studyId-chapterId.pgn.yaml
+++ b/doc/specs/tags/studies/api-study-studyId-chapterId.pgn.yaml
@@ -3,8 +3,8 @@ get:
   summary: Export one study chapter
   description: |
     Download one study chapter in PGN format.
-    If authenticated, then all public, unlisted, and private study's chapter are read.
-    If not, only public (non-unlisted) study's chapter are read.
+    If authenticated, then all public, unlisted, and private study chapters are read.
+    If not, only public (non-unlisted) study chapters are read.
   tags:
     - Studies
   security:

--- a/doc/specs/tags/studies/api-study-studyId.pgn.yaml
+++ b/doc/specs/tags/studies/api-study-studyId.pgn.yaml
@@ -3,8 +3,8 @@ get:
   summary: Export all chapters
   description: |
     Download all chapters of a study in PGN format.
-    If authenticated, then all public, unlisted, and private study's all chapters are read.
-    If not, only public (non-unlisted) study's chapters are read.
+    If authenticated, then all public, unlisted, and private study chapters are read.
+    If not, only public (non-unlisted) study chapters are read.
   tags:
     - Studies
   security:


### PR DESCRIPTION
Current study docs don't mention that when you add an OAuth token, you can read your own private study by hitting the study by id endpoint and the chapter + study id endpoint. I was confused, and only I tried. I was able to read my own studies via API this PR makes it clear in the docs themselves, so others don't get confused like me.