### PR TITLE
remove `upcoming` field from BroadcastTop schema

### DIFF
--- a/doc/specs/schemas/BroadcastTop.yaml
+++ b/doc/specs/schemas/BroadcastTop.yaml
@@ -5,6 +5,13 @@ properties:
     type: array
     items:
       $ref: "./BroadcastWithLastRound.yaml"
+  upcoming:
+    type: array
+    items:
+      $ref: "./BroadcastWithLastRound.yaml"
+      minItems: 0
+      maxItems: 0
+    deprecated: true
   past:
     type: object
     properties:


### PR DESCRIPTION
BC only according to lila/modules/relay/src/main/JsonView.scala

```scala
  def top(
      active: List[RelayCard],
      past: Paginator[WithLastRound]
  )(using Config) =
    Json.obj(
      "active" -> active.map(tourWithAnyRound(_)),
      "upcoming" -> Json.arr(), // BC
      "past" -> paginatorWriteNoNbResults.writes(past.map(tourWithAnyRound(_)))
    )
```

Creating a PR because not sure of latest procedure to change the docs. In a hurry, will check later if more need to be done