### PR TITLE
add Accept header options for x-chess-pgn vs x-ndjson

### DIFF
--- a/doc/specs/tags/games/api-games-user-username.yaml
+++ b/doc/specs/tags/games/api-games-user-username.yaml
@@ -15,6 +15,18 @@ get:
   security:
     - OAuth2: []
   parameters:
+    - in: header
+      name: Accept
+      description: |
+        Specify the desired response format.
+        Use `application/x-chess-pgn` to get the games in PGN format.
+        Use `application/x-ndjson` to get the games in ndjson format.
+      schema:
+        type: string
+        enum:
+          - application/x-chess-pgn
+          - application/x-ndjson
+        default: application/x-chess-pgn
     - in: path
       name: username
       description: The user name.


### PR DESCRIPTION
shows in docs as:
<img width="1322" height="426" alt="image" src="https://github.com/user-attachments/assets/bd9b40cc-e7d7-4876-b465-7d44d5a66852" />

and makes it a selectable option in the test client:
<img width="1255" height="334" alt="image" src="https://github.com/user-attachments/assets/1c10f0ec-3158-404a-a28c-f2011cedd0ef" />
