### PR TITLE
Generate `open-api.yaml` before calling vite

### DIFF
--- a/doc/package.json
+++ b/doc/package.json
@@ -16,7 +16,7 @@
     "vite-plugin-restart": "^2.0.0"
   },
   "scripts": {
-    "dev": "vite",
+    "dev": "pnpm bundle && vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "spectral": "spectral lint --fail-severity=warn specs/*.yaml",


### PR DESCRIPTION
Fixes bug where the documentation does not show on first load if `open-api.yaml` is not initially present when running `pnpm dev`.