### PR TITLE
photos property not included in response when creating a broadcast

### DIFF
--- a/doc/specs/schemas/BroadcastWithRounds.yaml
+++ b/doc/specs/schemas/BroadcastWithRounds.yaml
@@ -17,4 +17,3 @@ properties:
 required:
   - tour
   - rounds
-  - photos


### PR DESCRIPTION
lila source: https://github.com/lichess-org/lila/blob/1a4f7ca6af1fa87a6f622d25d0a94f2d0ff615c9/app/controllers/RelayTour.scala#L107