### PR TITLE
Add new .NET client to list

### DIFF
--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -36,6 +36,7 @@ info:
     - [Java general API](https://github.com/tors42/chariot)
     - [JavaScript & TypeScript general API](https://github.com/devjiwonchoi/equine)
     - [LichessNET - C# API Wrapper](https://github.com/Rabergsel/LichessNET)
+    - [.NET general API](https://github.com/Dblike/LichessSharp)
 
     ## Rate limiting
     All requests are rate limited using various strategies,


### PR DESCRIPTION
With .NET 10 now out, I've made a new .NET client that supports nearly all the existing endpoints. I plan to have this client stay up to date with any changes to the OpenAPI spec and I've invested a lot of time into endpoint verification and testing, to that end. 

The existing LichessNET client is a great option for those working on projects in .NET 8/9 and below, and I see mine as an alternative, not a replacement--it could be valuable to include both clients as an option. 

https://github.com/Dblike/LichessSharp