### PR TITLE
Don't include '200' in api docs for /top/ endpoint.

### DIFF
--- a/doc/specs/tags/users/api-player-top-nb-perfType.yaml
+++ b/doc/specs/tags/users/api-player-top-nb-perfType.yaml
@@ -7,7 +7,7 @@ get:
   description: |
     Get the leaderboard for a single speed or variant (a.k.a. `perfType`).
     There is no leaderboard for correspondence or puzzles.
-    See <https://lichess.org/player/top/200/bullet>.
+    See <https://lichess.org/player/top/100/bullet>.
   parameters:
     - in: path
       name: nb

--- a/types/lichess-api.d.ts
+++ b/types/lichess-api.d.ts
@@ -59,7 +59,7 @@ export interface paths {
      * Get one leaderboard
      * @description Get the leaderboard for a single speed or variant (a.k.a. `perfType`).
      *     There is no leaderboard for correspondence or puzzles.
-     *     See <https://lichess.org/player/top/200/bullet>.
+     *     See <https://lichess.org/player/top/100/bullet>.
      */
     get: operations["playerTopNbPerfType"];
     put?: never;


### PR DESCRIPTION
Since the maximum meaningful value is 100.