### PR TITLE
docs: add litchee (Rust) to the API clients list

### DIFF
--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -35,6 +35,7 @@ info:
     - [Python Board API for Certabo](https://github.com/haklein/certabo-lichess)
     - [Java general API](https://github.com/tors42/chariot)
     - [JavaScript & TypeScript general API](https://github.com/devjiwonchoi/equine)
+    - [Rust general API](https://github.com/obazin/litchee)
     - [LichessNET - C# API Wrapper](https://github.com/Rabergsel/LichessNET)
     - [.NET general API](https://github.com/Dblike/LichessSharp)
 


### PR DESCRIPTION
Adds [litchee](https://github.com/obazin/litchee) to the **Clients** list in the API introduction.

litchee is an async, builder-pattern Rust client for the Lichess API: full coverage of the documented operations, NDJSON streaming, strongly-typed DTOs and a matchable error enum, and OAuth2 PKCE ("Log in with Lichess"). It's published on [crates.io](https://crates.io/crates/litchee) with docs on [docs.rs](https://docs.rs/litchee).

There's currently no general-purpose Rust client in the list, so this fills that gap.