### PR TITLE
document POST /bookmark/{gameId}

### DIFF
--- a/doc/specs/lichess-api.yaml
+++ b/doc/specs/lichess-api.yaml
@@ -384,6 +384,9 @@ paths:
   /api/games/export/bookmarks:
     $ref: "./tags/games/api-games-export-bookmarks.yaml"
 
+  /bookmark/{gameId}:
+    $ref: "./tags/games/bookmark-gameId.yaml"
+
   /api/tv/channels:
     $ref: "./tags/tv/api-tv-channels.yaml"
 

--- a/doc/specs/tags/games/bookmark-gameId.yaml
+++ b/doc/specs/tags/games/bookmark-gameId.yaml
@@ -1,0 +1,36 @@
+post:
+  operationId: bookmarkToggle
+  summary: Bookmark or unbookmark a game
+  description: |
+    Add or remove a bookmark on a game, for the logged in user.
+    By default, the bookmark is toggled: added if absent, removed if present.
+    Use the `v` parameter to explicitly set the bookmark instead, making the request idempotent.
+    Bookmarked games can be downloaded with the [export your bookmarked games](#tag/games/GET/api/games/export/bookmarks) endpoint.
+  tags:
+    - Games
+  security:
+    - OAuth2: ["preference:write"]
+  parameters:
+    - in: path
+      name: gameId
+      schema:
+        type: string
+        example: "5IrD6Gzz"
+      required: true
+    - in: query
+      name: v
+      required: false
+      description: |
+        Explicitly set the bookmark instead of toggling it.
+        `true` adds the bookmark, `false` removes it.
+      schema:
+        type: boolean
+      example: true
+  responses:
+    "204":
+      description: The bookmark was successfully added or removed.
+      headers:
+        Access-Control-Allow-Origin:
+          schema:
+            type: string
+            default: "'*'"


### PR DESCRIPTION
closes #633 (Add docs for toggling bookmarking your own games #633)

documents `POST /bookmark/{gameId}`, which was opened to the `preference:write` OAuth scope in lichess-org/lila@5820514.

the following is taken from the lila source:

- toggles the bookmark on a game for the authenticated user, returning `204 No Content`.
- optional `v` query boolean sets the bookmark explicitly instead of toggling it, making the request idempotent.
- requires an OAuth token with the `preference:write` scope.

description cross-links to the existing [export your bookmarked games](#tag/games/GET/api/games/export/bookmarks) endpoint.

testing:
`build`, `lint`, `spectral`, `scalar-lint` and `check-format` all pass locally.