### PR TITLE
GamePlayerUser: user and rating are not always present

### DIFF
--- a/doc/specs/schemas/GamePlayerUser.yaml
+++ b/doc/specs/schemas/GamePlayerUser.yaml
@@ -1,10 +1,16 @@
 type: object
 
+description: |
+  One side of a game. `user` and `rating` are only present for registered
+  players: games against the computer have `aiLevel` instead, and fully
+  anonymous players have neither.
+
 properties:
   user:
     $ref: "./LightUser.yaml"
   rating:
     type: integer
+    description: Absent when the player is Stockfish or anonymous
   ratingDiff:
     type: integer
   name:
@@ -13,6 +19,7 @@ properties:
     type: boolean
   aiLevel:
     type: integer
+    description: Present instead of `user` and `rating` when the player is Stockfish
   analysis:
     type: object
     properties:
@@ -29,7 +36,3 @@ properties:
     required: [inaccuracy, mistake, blunder, acpl]
   team:
     type: string
-
-required:
-  - user
-  - rating


### PR DESCRIPTION
## Problem

`doc/specs/schemas/GamePlayerUser.yaml` declares:

```yaml
required:
  - user
  - rating
```

but the API omits both fields for non-registered players. Games against the computer return `aiLevel` **instead of** `user`/`rating` — a case the same schema already documents via its optional `aiLevel` property — and fully anonymous players have neither.

## Reproduction

```bash
curl -s -H 'Accept: application/json' https://lichess.org/game/export/p66Eii3m | jq .players
```

returns (production response, game vs Stockfish level 1):

```json
{
  "white": {
    "aiLevel": 1
  },
  "black": {
    "user": { "name": "aslan_teleporter", "id": "aslan_teleporter" },
    "rating": 1500,
    "provisional": true
  }
}
```

The same shape appears in `GET /api/games/user/{username}` NDJSON streams and everywhere else `GameJson` is used.

## Impact

Code generated from this spec (openapi-ts, openapi-generator, zod validators, etc.) rejects every game involving Stockfish or an anonymous player. We hit this in production: one AI game in an export batch failed strict response validation for the whole batch.

## Change

- Remove `user` and `rating` from `required`
- Add short descriptions documenting when each field is present

`redocly lint` passes with no new warnings.