### PR TITLE
Document `flair` and `description` parameters of `POST /api/study`.

### DIFF
--- a/doc/specs/tags/studies/api-study.yaml
+++ b/doc/specs/tags/studies/api-study.yaml
@@ -43,10 +43,9 @@ post:
             chat:
               $ref: "../../schemas/StudyUserSelection.yaml"
             sticky:
-              type: string
-              enum: ["true", "false"]
-              default: "true"
-              description: Keep everyone on the same chapter and position
+              type: boolean
+              default: true
+              description: Keep everyone on the same chapter and position.
             description:
               type: boolean
               default: false

--- a/doc/specs/tags/studies/api-study.yaml
+++ b/doc/specs/tags/studies/api-study.yaml
@@ -48,10 +48,9 @@ post:
               default: "true"
               description: Keep everyone on the same chapter and position
             description:
-              type: string
-              enum: ["true", "false"]
-              default: "false"
-              description: Add pinned study comment right under the board
+              type: boolean
+              default: false
+              description: Add pinned study comment right under the board.
           required:
             - name
             - visibility

--- a/doc/specs/tags/studies/api-study.yaml
+++ b/doc/specs/tags/studies/api-study.yaml
@@ -30,6 +30,8 @@ post:
                 * `public`: Default. Anyone can view the study, it appears on public listings
                 * `unlisted`: Only people with the link can view the study, it doesn't appear on public listings
                 * `private`: Only the study members can view the study
+            flair:
+              $ref: "../../schemas/Flair.yaml"
             computer:
               $ref: "../../schemas/StudyUserSelection.yaml"
             explorer:
@@ -45,6 +47,11 @@ post:
               enum: ["true", "false"]
               default: "true"
               description: Keep everyone on the same chapter and position
+            description:
+              type: string
+              enum: ["true", "false"]
+              default: "false"
+              description: Add pinned study comment right under the board
           required:
             - name
             - visibility


### PR DESCRIPTION
This PR documents the final two missing parameters of the `POST /api/study`:

Note that in the [backend code](https://github.com/lichess-org/lila/blob/3d8cbce69225c3ee8637dbea2a7605fb5e022e91/modules/study/src/main/StudyForm.scala#L37) `description` is an optional string that can currently be `true` or `false` (or actually `true` and `<something else>` IIUC), hence why I didn't choose a boolean. This behavior is similar to the already document `sticky` parameter. But suggestions welcome of course. *EDIT: changed to boolean.*

<img width="623" height="767" alt="image" src="https://github.com/user-attachments/assets/87223767-08e7-487b-a05f-99245898e43f" />