### PR TITLE
Fix `orientation` parameter in `POST /api/study/{studyId}/import-pgn`.

### DIFF
--- a/doc/specs/tags/studies/api-study-studyId-import-pgn.yaml
+++ b/doc/specs/tags/studies/api-study-studyId-import-pgn.yaml
@@ -38,11 +38,12 @@ post:
               maxLength: 100
             orientation:
               type: string
-              description: Default board orientation.
+              description: |
+                Board orientation.
+                If not specified, the orientation is automatically determined.
               enum:
                 - white
                 - black
-              default: white
             variant:
               $ref: "../../schemas/VariantKey.yaml"
             mode:


### PR DESCRIPTION
The current description (and default value) of the `orientation` parameter in `POST /api/study/{studyId}/import-pgn` is just wrong, as by default the board orientation is automatically determined.

This can be easily verified by experiment, or by inspecting the [backend code](https://github.com/lichess-org/lila/blob/946eac7bdca6a610d0ff44c31b46789419b6949c/modules/study/src/main/StudyForm.scala#L157).