### PR TITLE
Update `StudyPgn` example + introduce `BroadcastPgn` schema.

### DIFF
--- a/doc/specs/schemas/BroadcastPgn.yaml
+++ b/doc/specs/schemas/BroadcastPgn.yaml
@@ -1,0 +1,1 @@
+type: string

--- a/doc/specs/schemas/StudyPgn.yaml
+++ b/doc/specs/schemas/StudyPgn.yaml
@@ -1,15 +1,18 @@
 type: string
 
 example: |
-  [Event "All about the Sicilian Defense: Dragon Variation"]
-  [Site "https://lichess.org/study/8c8bmUfy/qwnXMwVC"]
+  [Event "♦ All about the Sicilian Defense ♦: Dragon Variation"]
+  [Date "2017.06.25"]
   [Result "*"]
-  [UTCDate "2017.06.25"]
-  [UTCTime "10:12:04"]
   [Variant "Standard"]
   [ECO "B76"]
   [Opening "Sicilian Defense: Dragon Variation, Yugoslav Attack, Panov Variation"]
-  [Annotator "https://lichess.org/@/Francesco_Super"]
+  [StudyName "♦ All about the Sicilian Defense ♦"]
+  [ChapterName "Dragon Variation"]
+  [ChapterURL "https://lichess.org/study/8c8bmUfy/qwnXMwVC"]
+  [Annotator "https://lichess.org/@/francesco_super"]
+  [UTCDate "2017.06.25"]
+  [UTCTime "10:12:04"]
 
   { This chapter will go over the Dragon Variation, a very common variation used by Black and it is the most aggressive variation in the Sicilian defense. }
-  1. e4 c5 2. Nf3 { Simple developing move to control the d4 square } { [%csl Gd4,Gc5][%cal Gf3d4,Gc5d4] } 2... d6 { [%cal Gd6e5] } (2... e6 3. d4 cxd4 4. Nxd4 Nf6 5. e5 (5. Nc3 { [%cal Ge4e5] }) 5... Qa5+) 3. d4 { Whites want the exchange of pawns } { [%cal Gc5d4] } 3... cxd4 { [%cal Gf3d4] } 4. Nxd4 { Whites are now ahead in development but blacks still have the two central pawns whereas whites only one. } { [%csl Ge7,Gd6,Ge4] } 4... Nf6 { Blacks are now developing their knight and threatening the e4 pawn } { [%csl Ge4][%cal Gf6e4] } 5. Nc3 { The e4 pawn is now protected by the c3 knight } { [%csl Ge4,Bc3][%cal Rf6e4,Bc3e4] } 5... g6 { This is the DRAGON VARIATION. g6 allows the dark-squared bishop to develop and move to g7, controlling the long dark-squared diagonal } { [%csl Gd4] } 6. Be3 { [%cal Gd1d2,Gf2f3,Ge1c1,Gg2g4,Gh2h4,Gg4g5] } (6. Be2 Bg7 7. O-O Nc6 8. Be3 { [%cal Ge3d4] } (8. f3 Nxe4 { [%cal Gg7d4,Gc6d4] } 9. Nxc6 Qb6+ { [%cal Gb6c6,Gb6g1] } 10. Kh1 Nxc3 { [%cal Gc3d1,Gc3e2] } 11. bxc3 bxc6 { [%cal Gc8a6] }) 8... O-O 9. Nb3 a6 { [%cal Gb7b5,Gb5b4,Ge2c4] }) 6... Bg7 (6... Ng4 { [%cal Gg4e3] } 7. Bb5+ { [%cal Gb5e8,Gb8d7,Gc8d7,Gd1g4] } 7... Nc6 8. Nxc6 bxc6 9. Bxc6+ { [%cal Gc6a8] }) 7. f3 { The key opening moves for White, who attempt to castle queenside , whereas f3 strengthens the pawn structure, connecting e4 to the h2 and g2, while White also plan pushing to g4 and possibly h4. } { [%csl Bf3,Be3][%cal Rg2g4,Rh2h4,Rg4g5] } 7... O-O (7... h5 { Is operating against g4. }) 8. Qd2 { [%csl Gh6,Gg7][%cal Ge1c1,Ga1d1,Re3h6,Rd2h6] } 8... Nc6 { [%csl Gc6,Gh6][%cal Gb8c6,Ge1c1,Ga7a6,Ge3h6] } 9. g4 (9. Bh6 { [%cal Ge3d4] } 9... Bxh6 10. Qxh6 Nxd4) 9... Be6 10. Nxe6 fxe6 { [%cal Gf8f1] } 11. O-O-O Ne5 12. Be2 { [%csl Gf3][%cal Re5f3,Bd1h1,Bg1d1] } 12... Qc7 { [%csl Gc4][%cal Ge5c4,Gc4e3,Gc4d2,Bf8c8,Yc7c3] } 13. h4 Nc4 *
+  1. e4 c5 2. Nf3 { Simple developing move to control the d4 square } { [%csl Gd4,Gc5][%cal Gf3d4,Gc5d4] } 2... d6 { [%cal Gd6e5] } (2... e6 3. d4 cxd4 4. Nxd4 Nf6 5. e5 (5. Nc3 { [%cal Ge4e5] }) 5... Qa5+) 3. d4 { Whites want the exchange of pawns } { [%cal Gc5d4] } 3... cxd4 { [%cal Gf3d4] } 4. Nxd4 { Whites are now ahead in development but blacks still have the two central pawns whereas whites only one. } { [%csl Ge7,Gd6,Ge4] } 4... Nf6 { Blacks are now developing their knight and threatening the e4 pawn } { [%csl Ge4][%cal Gf6e4] } 5. Nc3 { The e4 pawn is now protected by the c3 knight } { [%csl Ge4,Bc3][%cal Rf6e4,Bc3e4] } 5... g6 { This is the DRAGON VARIATION. g6 allows the dark-squared bishop to develop and move to g7, controlling the long dark-squared diagonal } { [%csl Gd4] } 6. Be3 { [%cal Gd1d2,Gf2f3,Ge1c1,Gg2g4,Gh2h4,Gg4g5] } (6. Be2 Bg7 7. O-O Nc6 8. Be3 { [%cal Ge3d4] } (8. f3 Nxe4 { [%cal Gg7d4,Gc6d4] } 9. Nxc6 Qb6+ { [%cal Gb6c6,Gb6g1] } 10. Kh1 Nxc3 { [%cal Gc3d1,Gc3e2] } 11. bxc3 bxc6 { [%cal Gc8a6] }) 8... O-O 9. Nb3 a6 { [%cal Gb7b5,Gb5b4,Ge2c4] }) 6... Bg7 (6... Ng4 { [%cal Gg4e3] } 7. Bb5+ { [%cal Gb5e8,Gb8d7,Gc8d7,Gd1g4] } 7... Nc6 8. Nxc6 bxc6 9. Bxc6+ { [%cal Gc6a8] }) 7. f3 { The key opening moves for White, who attempt to castle queenside , whereas f3 strengthens the pawn structure, connecting e4 to the h2 and g2, while White also plan pushing to g4 and possibly h4. } { [%csl Bf3,Be3][%cal Rg2g4,Rh2h4,Rg4g5] } 7... O-O (7... h5 { Is operating against g4. }) 8. Qd2 { [%csl Gh6,Gg7][%cal Ge1c1,Ga1d1,Re3h6,Rd2h6] } 8... Nc6 { [%csl Gc6,Gh6][%cal Gb8c6,Ge1c1,Ga7a6,Ge3h6] } 9. g4 (9. Bh6 { [%cal Ge3d4] } 9... Bxh6 10. Qxh6 Nxd4) 9... Be6 (9... Nxd4 10. Bxd4 Be6 { [%cal Rf1c4] }) 10. Nxe6 fxe6 { The rook has a powerful open file! } { [%cal Gf8f1] } 11. O-O-O Ne5 { [%csl Gf3][%cal Ge5f3] } 12. Be2 { [%csl Gf3][%cal Re5f3,Bd1h1,Bg1d1,Ge2f3] } 12... Qc8 { [%cal Gc8c1] } 13. h4 { [%cal Ge5c4] } *

--- a/doc/specs/schemas/_index.yaml
+++ b/doc/specs/schemas/_index.yaml
@@ -58,6 +58,9 @@ GamePlayerUser:
 GameJson:
   $ref: "./GameJson.yaml"
 
+BroadcastPgn:
+  $ref: "./BroadcastPgn.yaml"
+
 GamePgn:
   $ref: "./GamePgn.yaml"
 

--- a/doc/specs/tags/broadcasts/api-broadcast-broadcastTournamentId-pgn.yaml
+++ b/doc/specs/tags/broadcasts/api-broadcast-broadcastTournamentId-pgn.yaml
@@ -50,7 +50,7 @@ get:
       content:
         application/x-chess-pgn:
           schema:
-            $ref: "../../schemas/StudyPgn.yaml"
+            $ref: "../../schemas/BroadcastPgn.yaml"
           examples:
             pgn:
               $ref: "../../examples/broadcasts-exportAllRoundsAsPgn.pgn.yaml"

--- a/doc/specs/tags/broadcasts/api-broadcast-round-broadcastRoundId-pgn.yaml
+++ b/doc/specs/tags/broadcasts/api-broadcast-round-broadcastRoundId-pgn.yaml
@@ -46,7 +46,7 @@ get:
       content:
         application/x-chess-pgn:
           schema:
-            $ref: "../../schemas/StudyPgn.yaml"
+            $ref: "../../schemas/BroadcastPgn.yaml"
           examples:
             pgn:
               $ref: "../../examples/broadcasts-exportOneRoundAsPgn.pgn.yaml"

--- a/doc/specs/tags/broadcasts/api-stream-broadcast-group-broadcastGroupId-pgn.yaml
+++ b/doc/specs/tags/broadcasts/api-stream-broadcast-group-broadcastGroupId-pgn.yaml
@@ -50,7 +50,7 @@ get:
       content:
         application/x-chess-pgn:
           schema:
-            $ref: "../../schemas/StudyPgn.yaml"
+            $ref: "../../schemas/BroadcastPgn.yaml"
           examples:
             pgn:
               $ref: "../../examples/broadcasts-streamOngoingBroadcastRoundAsPgn.pgn.yaml"

--- a/doc/specs/tags/broadcasts/api-stream-broadcast-round-broadcastRoundId-pgn.yaml
+++ b/doc/specs/tags/broadcasts/api-stream-broadcast-round-broadcastRoundId-pgn.yaml
@@ -46,7 +46,7 @@ get:
       content:
         application/x-chess-pgn:
           schema:
-            $ref: "../../schemas/StudyPgn.yaml"
+            $ref: "../../schemas/BroadcastPgn.yaml"
           examples:
             pgn:
               $ref: "../../examples/broadcasts-streamOngoingBroadcastRoundAsPgn.pgn.yaml"


### PR DESCRIPTION
Update example in `StudyPgn` schema to the latest version, as quite a few things have changed to the tags.

I noticed that the `StudyPgn` schema is also used in some broadcast endpoints, unfortunately. This is large "overshadowed" in the interface by the fact that these endpoints also provide explicit examples, but this does not seem so clean to me. Maybe we should have a generic `Pgn` schema of type string without an explicit example?

This would also allow us  to get rid of `StudyPgn` (and use the new opaque `Pgn` schema) by defining explicit examples in the examples folder for all use cases, similar to how we do it with the broadcasts. This has the advantage that we can differentiate the examples better (e.g. export all chapters is now just the single chapter). If this would have been the case already, I imagine this PR would not have existed, as @fitztrev would likely have updated it in a0f82d031107e270f56d6bebbbdac4265926b90e.

What do you think?